### PR TITLE
Adds deployer service

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func main() {
 			if err != nil {
 				panic(err)
 			}
+			go newService.Boot()
 		}
 
 		return newServer

--- a/service/deployer/deployer.go
+++ b/service/deployer/deployer.go
@@ -123,4 +123,6 @@ func (s *standardDeployer) Boot() {
 			}
 		}
 	}
+
+	s.logger.Log("debug", "finished deployment loop")
 }

--- a/service/deployer/deployer.go
+++ b/service/deployer/deployer.go
@@ -1,0 +1,133 @@
+package deployer
+
+import (
+	"time"
+
+	microerror "github.com/giantswarm/microkit/error"
+	micrologger "github.com/giantswarm/microkit/logger"
+
+	"github.com/giantswarm/draughtsman/service/deployer/eventer"
+	"github.com/giantswarm/draughtsman/service/deployer/installer"
+)
+
+// DeployerType represents the type of Deployer to configure.
+type DeployerType string
+
+// Config represents the configuration used to create a Deployer.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+
+	// Settings.
+	Type DeployerType
+}
+
+// DefaultConfig provides a default configuration to create a new Deployer
+// service by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+
+		// Settings.
+		Type: StandardDeployer,
+	}
+}
+
+// New creates a new configured Deployer.
+func New(config Config) (Deployer, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "logger must not be empty")
+	}
+
+	var err error
+
+	var eventerService eventer.Eventer
+	{
+		eventerConfig := eventer.DefaultConfig()
+
+		eventerConfig.Logger = config.Logger
+
+		eventerService, err = eventer.New(eventerConfig)
+		if err != nil {
+			return nil, microerror.MaskAny(err)
+		}
+	}
+
+	var installerService installer.Installer
+	{
+		installerConfig := installer.DefaultConfig()
+
+		installerConfig.Logger = config.Logger
+
+		installerService, err = installer.New(installerConfig)
+		if err != nil {
+			return nil, microerror.MaskAny(err)
+		}
+	}
+
+	var newService Deployer
+
+	switch config.Type {
+	case StandardDeployer:
+		newService = &standardDeployer{
+			// Dependencies.
+			logger:    config.Logger,
+			eventer:   eventerService,
+			installer: installerService,
+		}
+	default:
+		return nil, microerror.MaskAnyf(invalidConfigError, "could not find deployer type")
+	}
+
+	return newService, nil
+}
+
+var StandardDeployer DeployerType = "StandardDeployer"
+
+// standardDeployer is an implementation of the Deployer interface.
+type standardDeployer struct {
+	// Dependencies.
+	logger    micrologger.Logger
+	eventer   eventer.Eventer
+	installer installer.Installer
+}
+
+// Boot starts the deployer.
+func (s *standardDeployer) Boot() {
+	s.logger.Log("debug", "starting deployer")
+
+	for {
+		deploymentEvents, waitTime, err := s.eventer.NewDeploymentEvents()
+		if err != nil {
+			s.logger.Log("error", "could not fetch deployment events", "message", err.Error())
+		}
+
+		for _, deploymentEvent := range deploymentEvents {
+			s.logger.Log("debug", "installing package", "name", deploymentEvent.Name)
+
+			if err := s.eventer.SetPending(deploymentEvent); err != nil {
+				s.logger.Log("error", "could not set pending event", "message", err.Error())
+			}
+
+			installErr := s.installer.Install(deploymentEvent)
+			if installErr == nil {
+				s.logger.Log("debug", "successfully installed package", "name", deploymentEvent.Name)
+
+				if err := s.eventer.SetSuccess(deploymentEvent); err != nil {
+					s.logger.Log("error", "could not set success event", "message", err.Error())
+				}
+			} else {
+				s.logger.Log("error", "could not install package", "name", deploymentEvent.Name, "message", err.Error())
+
+				if err := s.eventer.SetFailed(deploymentEvent); err != nil {
+					s.logger.Log("error", "could not set failed event", "message", err.Error())
+				}
+			}
+		}
+
+		s.logger.Log("debug", "waiting to check deployment events", "wait time", waitTime.String())
+		time.Sleep(waitTime)
+	}
+}

--- a/service/deployer/deployer.go
+++ b/service/deployer/deployer.go
@@ -102,7 +102,7 @@ func (s *standardDeployer) Boot() {
 	}
 
 	for deploymentEvent := range deploymentEventChannel {
-		s.logger.Log("debug", "installing package", "name", deploymentEvent.Name)
+		s.logger.Log("debug", "installing chart", "name", deploymentEvent.Name)
 
 		if err := s.eventer.SetPending(deploymentEvent); err != nil {
 			s.logger.Log("error", "could not set pending event", "message", err.Error())
@@ -110,13 +110,13 @@ func (s *standardDeployer) Boot() {
 
 		installErr := s.installer.Install(deploymentEvent)
 		if installErr == nil {
-			s.logger.Log("debug", "successfully installed package", "name", deploymentEvent.Name)
+			s.logger.Log("debug", "successfully installed chart", "name", deploymentEvent.Name)
 
 			if err := s.eventer.SetSuccess(deploymentEvent); err != nil {
 				s.logger.Log("error", "could not set success event", "message", err.Error())
 			}
 		} else {
-			s.logger.Log("error", "could not install package", "name", deploymentEvent.Name, "message", err.Error())
+			s.logger.Log("error", "could not install chart", "name", deploymentEvent.Name, "message", err.Error())
 
 			if err := s.eventer.SetFailed(deploymentEvent); err != nil {
 				s.logger.Log("error", "could not set failed event", "message", err.Error())

--- a/service/deployer/error.go
+++ b/service/deployer/error.go
@@ -1,0 +1,12 @@
+package deployer
+
+import (
+	"github.com/juju/errgo"
+)
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}

--- a/service/deployer/eventer/error.go
+++ b/service/deployer/eventer/error.go
@@ -1,0 +1,12 @@
+package eventer
+
+import (
+	"github.com/juju/errgo"
+)
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}

--- a/service/deployer/eventer/eventer.go
+++ b/service/deployer/eventer/eventer.go
@@ -63,7 +63,7 @@ type stubEventer struct {
 }
 
 func (e *stubEventer) NewDeploymentEvents() (chan DeploymentEvent, error) {
-	e.logger.Log("debug", "checking for deployment requests")
+	e.logger.Log("debug", "watching for deployment events")
 
 	ticker := time.NewTicker(10 * time.Second)
 	deploymentEventChannel := make(chan DeploymentEvent)

--- a/service/deployer/eventer/eventer.go
+++ b/service/deployer/eventer/eventer.go
@@ -1,0 +1,91 @@
+package eventer
+
+import (
+	"time"
+
+	microerror "github.com/giantswarm/microkit/error"
+	micrologger "github.com/giantswarm/microkit/logger"
+)
+
+// EventerType represents the type of Eventer to configure.
+type EventerType string
+
+// Config represents the configuration used to create an Eventer.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+
+	// Settings.
+	Type EventerType
+}
+
+// DefaultConfig provides a default configuration to create a new Eventer
+// service by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+
+		// Settings.
+		Type: StubEventer,
+	}
+}
+
+// New creates a new configured Eventer.
+func New(config Config) (Eventer, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "logger must not be empty")
+	}
+
+	var newService Eventer
+
+	switch config.Type {
+	case StubEventer:
+		newService = &stubEventer{
+			// Dependencies.
+			logger: config.Logger,
+		}
+	default:
+		return nil, microerror.MaskAnyf(invalidConfigError, "could not find eventer type")
+	}
+
+	return newService, nil
+}
+
+// StubEventer is an Eventer that just pretends it's a real Eventer.
+var StubEventer EventerType = "StubEventer"
+
+// stubEventer is a stub implementation of the Eventer interface.
+type stubEventer struct {
+	// Dependencies.
+	logger micrologger.Logger
+}
+
+func (e *stubEventer) NewDeploymentEvents() ([]DeploymentEvent, time.Duration, error) {
+	e.logger.Log("debug", "checking for deployment requests")
+
+	event := DeploymentEvent{
+		Name: "test-project",
+	}
+
+	return []DeploymentEvent{event}, 10 * time.Second, nil
+}
+
+func (e *stubEventer) SetPending(event DeploymentEvent) error {
+	e.logger.Log("debug", "setting pending", "event name", event.Name)
+
+	return nil
+}
+
+func (e *stubEventer) SetSuccess(event DeploymentEvent) error {
+	e.logger.Log("debug", "setting success", "event name", event.Name)
+
+	return nil
+}
+
+func (e *stubEventer) SetFailed(event DeploymentEvent) error {
+	e.logger.Log("debug", "setting failed", "event name", event.Name)
+
+	return nil
+}

--- a/service/deployer/eventer/eventer.go
+++ b/service/deployer/eventer/eventer.go
@@ -62,7 +62,7 @@ type stubEventer struct {
 	logger micrologger.Logger
 }
 
-func (e *stubEventer) NewDeploymentEvents() (chan DeploymentEvent, error) {
+func (e *stubEventer) NewDeploymentEvents() (<-chan DeploymentEvent, error) {
 	e.logger.Log("debug", "watching for deployment events")
 
 	ticker := time.NewTicker(10 * time.Second)

--- a/service/deployer/eventer/eventer.go
+++ b/service/deployer/eventer/eventer.go
@@ -62,14 +62,22 @@ type stubEventer struct {
 	logger micrologger.Logger
 }
 
-func (e *stubEventer) NewDeploymentEvents() ([]DeploymentEvent, time.Duration, error) {
+func (e *stubEventer) NewDeploymentEvents() (chan DeploymentEvent, error) {
 	e.logger.Log("debug", "checking for deployment requests")
 
-	event := DeploymentEvent{
-		Name: "test-project",
-	}
+	ticker := time.NewTicker(10 * time.Second)
+	deploymentEventChannel := make(chan DeploymentEvent)
 
-	return []DeploymentEvent{event}, 10 * time.Second, nil
+	go func() {
+		for range ticker.C {
+			e.logger.Log("debug", "sending deployment event")
+			deploymentEventChannel <- DeploymentEvent{
+				Name: "test-project",
+			}
+		}
+	}()
+
+	return deploymentEventChannel, nil
 }
 
 func (e *stubEventer) SetPending(event DeploymentEvent) error {

--- a/service/deployer/eventer/spec.go
+++ b/service/deployer/eventer/spec.go
@@ -1,8 +1,8 @@
 package eventer
 
-// DeploymentEvent represents a request for a package to be deployed.
+// DeploymentEvent represents a request for a chart to be deployed.
 type DeploymentEvent struct {
-	// Name is the name of the project to deploy, e.g: aws-operator.
+	// Name is the name of the project of the chart to deploy, e.g: aws-operator.
 	Name string
 }
 

--- a/service/deployer/eventer/spec.go
+++ b/service/deployer/eventer/spec.go
@@ -1,9 +1,5 @@
 package eventer
 
-import (
-	"time"
-)
-
 // DeploymentEvent represents a request for a package to be deployed.
 type DeploymentEvent struct {
 	// Name is the name of the project to deploy, e.g: aws-operator.
@@ -12,11 +8,11 @@ type DeploymentEvent struct {
 
 // Eventer represents a Service that checks for deployment events.
 type Eventer interface {
-	// NewDeploymentEvents returns a list of DeploymentEvents that have been
-	// created since the previous check, and a minimum time for the controller
-	// to wait before checking again.
-	// In case of error, the error will be non-nil.
-	NewDeploymentEvents() ([]DeploymentEvent, time.Duration, error)
+	// NewDeploymentEvents returns a channel of DeploymentEvents.
+	// This channel can be ranged over to receive DeploymentEvents as they come
+	// in.
+	// In case of error during setup, the error will be non-nil.
+	NewDeploymentEvents() (chan DeploymentEvent, error)
 
 	// SetPending updates the DeploymentEvent remote state to a pending state.
 	SetPending(DeploymentEvent) error

--- a/service/deployer/eventer/spec.go
+++ b/service/deployer/eventer/spec.go
@@ -1,0 +1,27 @@
+package eventer
+
+import (
+	"time"
+)
+
+// DeploymentEvent represents a request for a package to be deployed.
+type DeploymentEvent struct {
+	// Name is the name of the project to deploy, e.g: aws-operator.
+	Name string
+}
+
+// Eventer represents a Service that checks for deployment events.
+type Eventer interface {
+	// NewDeploymentEvents returns a list of DeploymentEvents that have been
+	// created since the previous check, and a minimum time for the controller
+	// to wait before checking again.
+	// In case of error, the error will be non-nil.
+	NewDeploymentEvents() ([]DeploymentEvent, time.Duration, error)
+
+	// SetPending updates the DeploymentEvent remote state to a pending state.
+	SetPending(DeploymentEvent) error
+	// SetSuccess updates the DeploymentEvent remote state to a success state.
+	SetSuccess(DeploymentEvent) error
+	// SetFailed updates the DeploymentEvent remote state to a failed state.
+	SetFailed(DeploymentEvent) error
+}

--- a/service/deployer/eventer/spec.go
+++ b/service/deployer/eventer/spec.go
@@ -12,7 +12,7 @@ type Eventer interface {
 	// This channel can be ranged over to receive DeploymentEvents as they come
 	// in.
 	// In case of error during setup, the error will be non-nil.
-	NewDeploymentEvents() (chan DeploymentEvent, error)
+	NewDeploymentEvents() (<-chan DeploymentEvent, error)
 
 	// SetPending updates the DeploymentEvent remote state to a pending state.
 	SetPending(DeploymentEvent) error

--- a/service/deployer/installer/error.go
+++ b/service/deployer/installer/error.go
@@ -1,0 +1,12 @@
+package installer
+
+import (
+	"github.com/juju/errgo"
+)
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}

--- a/service/deployer/installer/installer.go
+++ b/service/deployer/installer/installer.go
@@ -1,0 +1,69 @@
+package installer
+
+import (
+	microerror "github.com/giantswarm/microkit/error"
+	micrologger "github.com/giantswarm/microkit/logger"
+
+	"github.com/giantswarm/draughtsman/service/deployer/eventer"
+)
+
+// InstallerType represents the type of Installer to configure.
+type InstallerType string
+
+// Config represents the configuration used to create an Installer
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+
+	// Settings.
+	Type InstallerType
+}
+
+// DefaultConfig provides a default configuration to create a new Installer
+// service by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+
+		// Settings.
+		Type: StubInstaller,
+	}
+}
+
+// New creates a new configured Installer
+func New(config Config) (Installer, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "logger must not be empty")
+	}
+
+	var newService Installer
+
+	switch config.Type {
+	case StubInstaller:
+		newService = &stubInstaller{
+			// Dependencies.
+			logger: config.Logger,
+		}
+	default:
+		return nil, microerror.MaskAnyf(invalidConfigError, "could not find installer type")
+	}
+
+	return newService, nil
+}
+
+// StubInstaller is an Installer that just pretends it's a real Installer.
+var StubInstaller InstallerType = "StubInstaller"
+
+// stubInstaller is a stub implementation of the Installer interface.
+type stubInstaller struct {
+	// Dependencies.
+	logger micrologger.Logger
+}
+
+func (i *stubInstaller) Install(event eventer.DeploymentEvent) error {
+	i.logger.Log("debug", "installing package", "name", event.Name)
+
+	return nil
+}

--- a/service/deployer/installer/installer.go
+++ b/service/deployer/installer/installer.go
@@ -10,7 +10,7 @@ import (
 // InstallerType represents the type of Installer to configure.
 type InstallerType string
 
-// Config represents the configuration used to create an Installer
+// Config represents the configuration used to create an Installer.
 type Config struct {
 	// Dependencies.
 	Logger micrologger.Logger
@@ -31,7 +31,7 @@ func DefaultConfig() Config {
 	}
 }
 
-// New creates a new configured Installer
+// New creates a new configured Installer.
 func New(config Config) (Installer, error) {
 	// Dependencies.
 	if config.Logger == nil {
@@ -63,7 +63,7 @@ type stubInstaller struct {
 }
 
 func (i *stubInstaller) Install(event eventer.DeploymentEvent) error {
-	i.logger.Log("debug", "installing package", "name", event.Name)
+	i.logger.Log("debug", "installing chart", "name", event.Name)
 
 	return nil
 }

--- a/service/deployer/installer/spec.go
+++ b/service/deployer/installer/spec.go
@@ -4,9 +4,9 @@ import (
 	"github.com/giantswarm/draughtsman/service/deployer/eventer"
 )
 
-// Installer represents a Service that installs packages.
+// Installer represents a Service that installs charts.
 type Installer interface {
-	// Install takes a DeploymentEvent, and installs the referenced package.
+	// Install takes a DeploymentEvent, and installs the referenced chart.
 	// If an error occurs, the returned error will be non-nil.
 	Install(eventer.DeploymentEvent) error
 }

--- a/service/deployer/installer/spec.go
+++ b/service/deployer/installer/spec.go
@@ -1,0 +1,12 @@
+package installer
+
+import (
+	"github.com/giantswarm/draughtsman/service/deployer/eventer"
+)
+
+// Installer represents a Service that installs packages.
+type Installer interface {
+	// Install takes a DeploymentEvent, and installs the referenced package.
+	// If an error occurs, the returned error will be non-nil.
+	Install(eventer.DeploymentEvent) error
+}

--- a/service/deployer/spec.go
+++ b/service/deployer/spec.go
@@ -1,0 +1,10 @@
+package deployer
+
+// Deployer is a service that handles deployments.
+// While the deployment control loop logic is unlikely to change drastically,
+// the Deployer interface exists to allow for it in the future.
+// e.g: installations that only allow for deployments during certain
+// maintenance windows.
+type Deployer interface {
+	Boot()
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1253

Rough idea here is to show the general structure and control loop.

Will add a new eventer that uses github deployment events, and an installer that uses helm in further PRs.