### PR TITLE
Filter out finished deployments

### DIFF
--- a/service/deployer/eventer/github/client.go
+++ b/service/deployer/eventer/github/client.go
@@ -44,9 +44,9 @@ func (e *GithubEventer) request(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-// filterDeployments filters out any deployments we don't want,
-// such as deployments for other installations.
-func (e *GithubEventer) filterDeployments(deployments []deployment) []deployment {
+// filterDeploymentsByEnvironment filters out deployments that do not apply
+// to this environment.
+func (e *GithubEventer) filterDeploymentsByEnvironment(deployments []deployment) []deployment {
 	matches := []deployment{}
 
 	for _, deployment := range deployments {
@@ -113,7 +113,7 @@ func (e *GithubEventer) fetchNewDeploymentEvents(project string, etagMap map[str
 		return nil, microerror.MaskAny(err)
 	}
 
-	deployments = e.filterDeployments(deployments)
+	deployments = e.filterDeploymentsByEnvironment(deployments)
 
 	if len(deployments) > 0 {
 		e.logger.Log("debug", "found new deployment events", "project", project)

--- a/service/deployer/eventer/github/client.go
+++ b/service/deployer/eventer/github/client.go
@@ -13,12 +13,12 @@ import (
 
 const (
 	// deploymentUrlFormat is the string format for the GitHub
-	// API call to fetch Deployments.
+	// API call for Deployments.
 	// See: https://developer.github.com/v3/repos/deployments/#list-deployments
 	deploymentUrlFormat = "https://api.github.com/repos/%s/%s/deployments"
 
 	// deploymentStatusUrlFormat is the string format for the
-	// GitHub API call to post Deployment Statuses.
+	// GitHub API call for Deployment Statuses.
 	// See: https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
 	deploymentStatusUrlFormat = "https://api.github.com/repos/%s/%s/deployments/%v/statuses"
 
@@ -51,6 +51,30 @@ func (e *GithubEventer) filterDeploymentsByEnvironment(deployments []deployment)
 
 	for _, deployment := range deployments {
 		if deployment.Environment == e.environment {
+			matches = append(matches, deployment)
+		}
+	}
+
+	return matches
+}
+
+// filterDeploymentsByStatus filters out deployments that are finished -
+// that is, there exists at least one status that is not pending.
+func (e *GithubEventer) filterDeploymentsByStatus(deployments []deployment) []deployment {
+	matches := []deployment{}
+
+	for _, deployment := range deployments {
+		// If there are any statuses apart from pending, we consider the
+		// deployment finished, and do not act on it.
+		isPending := true
+		for _, status := range deployment.Statuses {
+			if status.State != pendingState {
+				isPending = false
+				break
+			}
+		}
+
+		if isPending {
 			matches = append(matches, deployment)
 		}
 	}
@@ -115,6 +139,17 @@ func (e *GithubEventer) fetchNewDeploymentEvents(project string, etagMap map[str
 
 	deployments = e.filterDeploymentsByEnvironment(deployments)
 
+	for index, deployment := range deployments {
+		deploymentStatuses, err := e.fetchDeploymentStatus(project, deployment)
+		if err != nil {
+			return nil, microerror.MaskAny(err)
+		}
+
+		deployments[index].Statuses = deploymentStatuses
+	}
+
+	deployments = e.filterDeploymentsByStatus(deployments)
+
 	if len(deployments) > 0 {
 		e.logger.Log("debug", "found new deployment events", "project", project)
 	}
@@ -122,7 +157,48 @@ func (e *GithubEventer) fetchNewDeploymentEvents(project string, etagMap map[str
 	return deployments, nil
 }
 
-// postDeploymentEventStatus posts a Deployment Status for the given Deployment.
+// fetchDeploymentStatus fetches Deployment Statuses for the given Deployment.
+func (e *GithubEventer) fetchDeploymentStatus(project string, deployment deployment) ([]deploymentStatus, error) {
+	url := fmt.Sprintf(
+		deploymentStatusUrlFormat,
+		e.organisation,
+		project,
+		deployment.ID,
+	)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	startTime := time.Now()
+
+	resp, err := e.request(req)
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+	defer resp.Body.Close()
+
+	updateDeploymentStatusMetrics("GET", e.organisation, project, resp.StatusCode, startTime)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, microerror.MaskAnyf(unexpectedStatusCode, fmt.Sprintf("received non-200 status code: %v", resp.StatusCode))
+	}
+
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	var deploymentStatuses []deploymentStatus
+	if err := json.Unmarshal(bytes, &deploymentStatuses); err != nil {
+		return nil, microerror.MaskAny(err)
+	}
+
+	return deploymentStatuses, nil
+}
+
+// postDeploymentStatus posts a Deployment Status for the given Deployment.
 func (e *GithubEventer) postDeploymentStatus(project string, id int, state deploymentStatusState) error {
 	e.logger.Log("debug", "posting deployment status", "project", project, "id", id, "state", state)
 
@@ -155,7 +231,7 @@ func (e *GithubEventer) postDeploymentStatus(project string, id int, state deplo
 	}
 	defer resp.Body.Close()
 
-	updateDeploymentStatusMetrics(e.organisation, project, resp.StatusCode, startTime)
+	updateDeploymentStatusMetrics("POST", e.organisation, project, resp.StatusCode, startTime)
 
 	if resp.StatusCode != http.StatusCreated {
 		return microerror.MaskAnyf(unexpectedStatusCode, fmt.Sprintf("received non-200 status code: %v", resp.StatusCode))

--- a/service/deployer/eventer/github/client_test.go
+++ b/service/deployer/eventer/github/client_test.go
@@ -58,3 +58,98 @@ func TestFilterDeploymentsByEnvironment(t *testing.T) {
 		}
 	}
 }
+
+// TestFilterDeploymentsByStatus tests the filterDeploymentsByStatus method.
+func TestFilterDeploymentsByStatus(t *testing.T) {
+	tests := []struct {
+		deployments         []deployment
+		expectedDeployments []deployment
+	}{
+		// Test that no deployments filters to no deployments.
+		{
+			deployments:         []deployment{},
+			expectedDeployments: []deployment{},
+		},
+
+		// Test that a pending deployment is kept.
+		{
+			deployments: []deployment{
+				deployment{
+					Statuses: []deploymentStatus{
+						deploymentStatus{State: pendingState},
+					},
+				},
+			},
+			expectedDeployments: []deployment{
+				deployment{
+					Statuses: []deploymentStatus{
+						deploymentStatus{State: pendingState},
+					},
+				},
+			},
+		},
+
+		// Test that a success only deployment is not kept.
+		{
+			deployments: []deployment{
+				deployment{
+					Statuses: []deploymentStatus{
+						deploymentStatus{State: successState},
+					},
+				},
+			},
+			expectedDeployments: []deployment{},
+		},
+
+		// Test that a failure only deployment is not kept.
+		{
+			deployments: []deployment{
+				deployment{
+					Statuses: []deploymentStatus{
+						deploymentStatus{State: failedState},
+					},
+				},
+			},
+			expectedDeployments: []deployment{},
+		},
+
+		// Test that a deployment that was pending, and is now successful, is not kept.
+		{
+			deployments: []deployment{
+				deployment{
+					Statuses: []deploymentStatus{
+						deploymentStatus{State: pendingState},
+						deploymentStatus{State: successState},
+					},
+				},
+			},
+			expectedDeployments: []deployment{},
+		},
+
+		// Test that a deployment that was pending, and is now failed, is not kept.
+		{
+			deployments: []deployment{
+				deployment{
+					Statuses: []deploymentStatus{
+						deploymentStatus{State: pendingState},
+						deploymentStatus{State: failedState},
+					},
+				},
+			},
+			expectedDeployments: []deployment{},
+		},
+	}
+
+	for index, test := range tests {
+		e := GithubEventer{}
+
+		returnedDeployments := e.filterDeploymentsByStatus(test.deployments)
+
+		if !reflect.DeepEqual(test.expectedDeployments, returnedDeployments) {
+			t.Fatalf(
+				"%v\nexpected: %#v\nreturned: %#v\n",
+				index, test.expectedDeployments, returnedDeployments,
+			)
+		}
+	}
+}

--- a/service/deployer/eventer/github/client_test.go
+++ b/service/deployer/eventer/github/client_test.go
@@ -1,0 +1,60 @@
+package github
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestFilterDeploymentsByEnvironment tests the filterDeployments method.
+func TestFilterDeploymentsByEnvironment(t *testing.T) {
+	tests := []struct {
+		deployments         []deployment
+		environment         string
+		expectedDeployments []deployment
+	}{
+		// Test that no deployments filters to no deployments.
+		{
+			deployments:         []deployment{},
+			environment:         "covfefe",
+			expectedDeployments: []deployment{},
+		},
+
+		// Test that a deployment for the installation is kept.
+		{
+			deployments: []deployment{
+				deployment{Environment: "production"},
+			},
+			environment: "production",
+			expectedDeployments: []deployment{
+				deployment{Environment: "production"},
+			},
+		},
+
+		// Test that only this environment's deployments are kept.
+		{
+			deployments: []deployment{
+				deployment{Environment: "development"},
+				deployment{Environment: "production"},
+			},
+			environment: "development",
+			expectedDeployments: []deployment{
+				deployment{Environment: "development"},
+			},
+		},
+	}
+
+	for index, test := range tests {
+		e := GithubEventer{
+			environment: test.environment,
+		}
+
+		returnedDeployments := e.filterDeploymentsByEnvironment(test.deployments)
+
+		if !reflect.DeepEqual(test.expectedDeployments, returnedDeployments) {
+			t.Fatalf(
+				"%v\nexpected: %#v\nreturned: %#v\n",
+				index, test.expectedDeployments, returnedDeployments,
+			)
+		}
+	}
+}

--- a/service/deployer/eventer/github/metrics.go
+++ b/service/deployer/eventer/github/metrics.go
@@ -70,7 +70,7 @@ var (
 			Name:      "github_deployment_status_duration_milliseconds",
 			Help:      "Time taken to request GitHub deployment statuses.",
 		},
-		[]string{"organisation", "project", "code"},
+		[]string{"method", "organisation", "project", "code"},
 	)
 	deploymentStatusResponseCodeTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -79,7 +79,7 @@ var (
 			Name:      "github_deployment_status_response_code",
 			Help:      "Response codes of GitHub API requests for deployment statuses.",
 		},
-		[]string{"organisation", "project", "code"},
+		[]string{"method", "organisation", "project", "code"},
 	)
 )
 
@@ -132,8 +132,9 @@ func updateDeploymentMetrics(organisation, project string, statusCode int, start
 
 // updateDeploymentStatusMetrics is a utility function for updating metrics
 // related to Deployment Status API calls.
-func updateDeploymentStatusMetrics(organisation, project string, statusCode int, startTime time.Time) {
+func updateDeploymentStatusMetrics(method, organisation, project string, statusCode int, startTime time.Time) {
 	deploymentStatusRequestDuration.WithLabelValues(
+		method,
 		organisation,
 		project,
 		strconv.Itoa(statusCode),
@@ -142,6 +143,7 @@ func updateDeploymentStatusMetrics(organisation, project string, statusCode int,
 	)
 
 	deploymentStatusResponseCodeTotal.WithLabelValues(
+		method,
 		organisation,
 		project,
 		strconv.Itoa(statusCode),

--- a/service/deployer/eventer/github/spec.go
+++ b/service/deployer/eventer/github/spec.go
@@ -15,6 +15,9 @@ type deployment struct {
 
 	// Sha is the SHA hash of the commit the deployment references.
 	Sha string `json:"sha"`
+
+	// Statuses is the deployment statuses of this deployment.
+	Statuses []deploymentStatus
 }
 
 // Deploymespec.ntEvent returns the deployment as a DeploymentEvent.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1253

Deployments that we are finished with, e.g: they have a success or failed status, should not be worked upon later.