### PR TITLE
Adds support for configuring deployer, eventer and installer via flags

### DIFF
--- a/flag/service/deployer/deployer.go
+++ b/flag/service/deployer/deployer.go
@@ -8,4 +8,5 @@ import (
 type Deployer struct {
 	Eventer   eventer.Eventer
 	Installer installer.Installer
+	Type      string
 }

--- a/flag/service/deployer/eventer/eventer.go
+++ b/flag/service/deployer/eventer/eventer.go
@@ -6,4 +6,5 @@ import (
 
 type Eventer struct {
 	GitHub github.GitHub
+	Type   string
 }

--- a/flag/service/deployer/installer/installer.go
+++ b/flag/service/deployer/installer/installer.go
@@ -6,4 +6,5 @@ import (
 
 type Installer struct {
 	Helm helm.Helm
+	Type string
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,9 @@ import (
 	"github.com/giantswarm/draughtsman/flag"
 	"github.com/giantswarm/draughtsman/server"
 	"github.com/giantswarm/draughtsman/service"
+	"github.com/giantswarm/draughtsman/service/deployer"
+	"github.com/giantswarm/draughtsman/service/deployer/eventer/github"
+	"github.com/giantswarm/draughtsman/service/deployer/installer/helm"
 )
 
 var (
@@ -101,6 +104,10 @@ func main() {
 	}
 
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
+
+	daemonCommand.PersistentFlags().String(f.Service.Deployer.Type, string(deployer.StandardDeployer), "Which deployer to use for deployment management.")
+	daemonCommand.PersistentFlags().String(f.Service.Deployer.Eventer.Type, string(github.GithubEventerType), "Which eventer to use for event management.")
+	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Type, string(helm.HelmInstallerType), "Which installer to use for installation management.")
 
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Eventer.GitHub.Environment, "", "Environment name that draughtsman is running in.")
 	daemonCommand.PersistentFlags().Duration(f.Service.Deployer.Eventer.GitHub.HTTPClientTimeout, 10*time.Second, "Timeout for requests to GitHub.")

--- a/service/deployer/deployer.go
+++ b/service/deployer/deployer.go
@@ -38,8 +38,6 @@ func DefaultConfig() Config {
 		// Settings.
 		Flag:  nil,
 		Viper: nil,
-
-		Type: StandardDeployer,
 	}
 }
 
@@ -61,6 +59,8 @@ func New(config Config) (Deployer, error) {
 		eventerConfig.Flag = config.Flag
 		eventerConfig.Viper = config.Viper
 
+		eventerConfig.Type = eventerspec.EventerType(config.Viper.GetString(config.Flag.Service.Deployer.Eventer.Type))
+
 		eventerService, err = eventer.New(eventerConfig)
 		if err != nil {
 			return nil, microerror.MaskAny(err)
@@ -75,6 +75,8 @@ func New(config Config) (Deployer, error) {
 
 		installerConfig.Flag = config.Flag
 		installerConfig.Viper = config.Viper
+
+		installerConfig.Type = installerspec.InstallerType(config.Viper.GetString(config.Flag.Service.Deployer.Installer.Type))
 
 		installerService, err = installer.New(installerConfig)
 		if err != nil {

--- a/service/deployer/eventer/eventer.go
+++ b/service/deployer/eventer/eventer.go
@@ -33,8 +33,6 @@ func DefaultConfig() Config {
 		// Settings.
 		Flag:  nil,
 		Viper: nil,
-
-		Type: github.GithubEventerType,
 	}
 }
 

--- a/service/deployer/installer/installer.go
+++ b/service/deployer/installer/installer.go
@@ -33,8 +33,6 @@ func DefaultConfig() Config {
 		// Settings.
 		Flag:  nil,
 		Viper: nil,
-
-		Type: helm.HelmInstallerType,
 	}
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -64,6 +64,8 @@ func New(config Config) (*Service, error) {
 		deployerConfig.Flag = config.Flag
 		deployerConfig.Viper = config.Viper
 
+		deployerConfig.Type = deployer.DeployerType(config.Viper.GetString(config.Flag.Service.Deployer.Type))
+
 		deployerService, err = deployer.New(deployerConfig)
 		if err != nil {
 			return nil, microerror.MaskAny(err)


### PR DESCRIPTION
This PR adds support for configuring the deployer, eventer and installer via command line flags. We don't need it just yet (we only have one deployer, eventer and installer), but it was bugging me :D