### PR TITLE
File configurer

### DIFF
--- a/flag/service/deployer/installer/configurer/configurer.go
+++ b/flag/service/deployer/installer/configurer/configurer.go
@@ -1,0 +1,10 @@
+package configurer
+
+import (
+	"github.com/giantswarm/draughtsman/flag/service/deployer/installer/configurer/file"
+)
+
+type Configurer struct {
+	File file.File
+	Type string
+}

--- a/flag/service/deployer/installer/configurer/file/file.go
+++ b/flag/service/deployer/installer/configurer/file/file.go
@@ -1,0 +1,5 @@
+package file
+
+type File struct {
+	Path string
+}

--- a/flag/service/deployer/installer/installer.go
+++ b/flag/service/deployer/installer/installer.go
@@ -1,10 +1,12 @@
 package installer
 
 import (
+	"github.com/giantswarm/draughtsman/flag/service/deployer/installer/configurer"
 	"github.com/giantswarm/draughtsman/flag/service/deployer/installer/helm"
 )
 
 type Installer struct {
-	Helm helm.Helm
-	Type string
+	Helm       helm.Helm
+	Configurer configurer.Configurer
+	Type       string
 }

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/giantswarm/draughtsman/service"
 	"github.com/giantswarm/draughtsman/service/deployer"
 	"github.com/giantswarm/draughtsman/service/deployer/eventer/github"
+	"github.com/giantswarm/draughtsman/service/deployer/installer/configurer/file"
 	"github.com/giantswarm/draughtsman/service/deployer/installer/helm"
 )
 
@@ -108,6 +109,7 @@ func main() {
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Type, string(deployer.StandardDeployer), "Which deployer to use for deployment management.")
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Eventer.Type, string(github.GithubEventerType), "Which eventer to use for event management.")
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Type, string(helm.HelmInstallerType), "Which installer to use for installation management.")
+	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Configurer.Type, string(file.FileConfigurerType), "Which configurer to use for configuration management.")
 
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Eventer.GitHub.Environment, "", "Environment name that draughtsman is running in.")
 	daemonCommand.PersistentFlags().Duration(f.Service.Deployer.Eventer.GitHub.HTTPClientTimeout, 10*time.Second, "Timeout for requests to GitHub.")
@@ -121,6 +123,8 @@ func main() {
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Helm.Password, "", "Password for Helm CNR registry.")
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Helm.Registry, "quay.io", "URL for Helm CNR registry.")
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Helm.Username, "", "Username for Helm CNR registry.")
+
+	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Configurer.File.Path, "", "Path to values file.")
 
 	newCommand.CobraCommand().Execute()
 }

--- a/service/deployer/installer/configurer/configurer.go
+++ b/service/deployer/installer/configurer/configurer.go
@@ -1,0 +1,76 @@
+package configurer
+
+import (
+	"github.com/spf13/viper"
+
+	microerror "github.com/giantswarm/microkit/error"
+	micrologger "github.com/giantswarm/microkit/logger"
+
+	"github.com/giantswarm/draughtsman/flag"
+	"github.com/giantswarm/draughtsman/service/deployer/installer/configurer/file"
+	"github.com/giantswarm/draughtsman/service/deployer/installer/configurer/spec"
+)
+
+// Config represents the configuration used to create a Configurer.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+
+	// Settings.
+	Flag  *flag.Flag
+	Viper *viper.Viper
+
+	Type spec.ConfigurerType
+}
+
+// DefaultConfig provides a default configuration to create a new Configurer
+// service by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+
+		// Settings.
+		Flag:  nil,
+		Viper: nil,
+	}
+}
+
+// New creates a new configured Configurer.
+func New(config Config) (spec.Configurer, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "logger must not be empty")
+	}
+
+	// Settings.
+	if config.Flag == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "flag must not be empty")
+	}
+	if config.Viper == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "viper must not be empty")
+	}
+
+	var err error
+
+	var newConfigurer spec.Configurer
+
+	switch config.Type {
+	case file.FileConfigurerType:
+		fileConfig := file.DefaultConfig()
+
+		fileConfig.Logger = config.Logger
+
+		fileConfig.Path = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Configurer.File.Path)
+
+		newConfigurer, err = file.New(fileConfig)
+		if err != nil {
+			return nil, microerror.MaskAny(err)
+		}
+
+	default:
+		return nil, microerror.MaskAnyf(invalidConfigError, "configurer type not implemented")
+	}
+
+	return newConfigurer, nil
+}

--- a/service/deployer/installer/configurer/error.go
+++ b/service/deployer/installer/configurer/error.go
@@ -1,0 +1,12 @@
+package configurer
+
+import (
+	"github.com/juju/errgo"
+)
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}

--- a/service/deployer/installer/configurer/file/error.go
+++ b/service/deployer/installer/configurer/file/error.go
@@ -1,0 +1,12 @@
+package file
+
+import (
+	"github.com/juju/errgo"
+)
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}

--- a/service/deployer/installer/configurer/file/file.go
+++ b/service/deployer/installer/configurer/file/file.go
@@ -1,0 +1,66 @@
+package file
+
+import (
+	"os"
+
+	microerror "github.com/giantswarm/microkit/error"
+	micrologger "github.com/giantswarm/microkit/logger"
+
+	"github.com/giantswarm/draughtsman/service/deployer/installer/configurer/spec"
+)
+
+// FileConfigurerType is a Configurer that uses a normal file.
+var FileConfigurerType spec.ConfigurerType = "FileConfigurer"
+
+// Config represents the configuration used to create a File Configurer.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+
+	// Settings.
+	Path string
+}
+
+// DefaultConfig provides a default configuration to create a new File
+// Configurer by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+	}
+}
+
+// New creates a new configured File Configurer.
+func New(config Config) (*FileConfigurer, error) {
+	if config.Path == "" {
+		return nil, microerror.MaskAnyf(invalidConfigError, "path must not be empty")
+	}
+
+	if _, err := os.Stat(config.Path); os.IsNotExist(err) {
+		return nil, microerror.MaskAnyf(invalidConfigError, "path does not exist")
+	}
+
+	configurer := &FileConfigurer{
+		// Dependencies.
+		logger: config.Logger,
+
+		// Settings.
+		path: config.Path,
+	}
+
+	return configurer, nil
+}
+
+// FileConfigurer is an implementation of the Configurer interface,
+// that uses a plain file to hold configuration.
+type FileConfigurer struct {
+	// Dependencies.
+	logger micrologger.Logger
+
+	// Settings.
+	path string
+}
+
+func (c *FileConfigurer) File() (string, error) {
+	return c.path, nil
+}

--- a/service/deployer/installer/configurer/spec/spec.go
+++ b/service/deployer/installer/configurer/spec/spec.go
@@ -1,0 +1,10 @@
+package spec
+
+// ConfigurerType represents the type of Configurer to configure.
+type ConfigurerType string
+
+// Configurer represents a Service that provides a Helm configuration file.
+type Configurer interface {
+	// File returns a path to a file to use for Helm values.
+	File() (string, error)
+}

--- a/service/deployer/installer/helm/helm.go
+++ b/service/deployer/installer/helm/helm.go
@@ -91,7 +91,7 @@ func New(config Config) (*HelmInstaller, error) {
 	return installer, nil
 }
 
-// HelmInstaller is an implementation of the Helm interface,
+// HelmInstaller is an implementation of the Installer interface,
 // that uses Helm to install charts.
 type HelmInstaller struct {
 	// Dependencies.

--- a/service/deployer/installer/helm/helm.go
+++ b/service/deployer/installer/helm/helm.go
@@ -13,6 +13,7 @@ import (
 	micrologger "github.com/giantswarm/microkit/logger"
 
 	eventerspec "github.com/giantswarm/draughtsman/service/deployer/eventer/spec"
+	configurerspec "github.com/giantswarm/draughtsman/service/deployer/installer/configurer/spec"
 	"github.com/giantswarm/draughtsman/service/deployer/installer/spec"
 )
 
@@ -31,7 +32,8 @@ var HelmInstallerType spec.InstallerType = "HelmInstaller"
 // Config represents the configuration used to create a Helm Installer.
 type Config struct {
 	// Dependencies.
-	Logger micrologger.Logger
+	Logger     micrologger.Logger
+	Configurer configurerspec.Configurer
 
 	// Settings.
 	HelmBinaryPath string
@@ -46,7 +48,8 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		// Dependencies.
-		Logger: nil,
+		Logger:     nil,
+		Configurer: nil,
 	}
 }
 
@@ -74,7 +77,8 @@ func New(config Config) (*HelmInstaller, error) {
 
 	installer := &HelmInstaller{
 		// Dependencies.
-		logger: config.Logger,
+		logger:     config.Logger,
+		configurer: config.Configurer,
 
 		// Settings.
 		helmBinaryPath: config.HelmBinaryPath,
@@ -95,7 +99,8 @@ func New(config Config) (*HelmInstaller, error) {
 // that uses Helm to install charts.
 type HelmInstaller struct {
 	// Dependencies.
-	logger micrologger.Logger
+	logger     micrologger.Logger
+	configurer configurerspec.Configurer
 
 	// Settings.
 	helmBinaryPath string
@@ -202,12 +207,17 @@ func (i *HelmInstaller) Install(event eventerspec.DeploymentEvent) error {
 
 	i.logger.Log("debug", "downloaded chart", "tarball", tarballPath)
 
+	valuesFile, err := i.configurer.File()
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
 	if err := i.runHelmCommand(
 		"install",
 		"install",
 		tarballPath,
-		// "--values",
-		// "./values.yaml",
+		"--values",
+		valuesFile,
 		"--wait",
 	); err != nil {
 		return microerror.MaskAny(err)

--- a/service/deployer/installer/installer.go
+++ b/service/deployer/installer/installer.go
@@ -64,7 +64,9 @@ func New(config Config) (spec.Installer, error) {
 		configurerConfig.Flag = config.Flag
 		configurerConfig.Viper = config.Viper
 
-		configurerConfig.Type = configurerspec.ConfigurerType(config.Viper.GetString(config.Flag.Service.Deployer.Installer.Configurer.Type))
+		configurerConfig.Type = configurerspec.ConfigurerType(
+			config.Viper.GetString(config.Flag.Service.Deployer.Installer.Configurer.Type),
+		)
 
 		configurerService, err = configurer.New(configurerConfig)
 		if err != nil {

--- a/service/deployer/installer/installer.go
+++ b/service/deployer/installer/installer.go
@@ -7,6 +7,8 @@ import (
 	micrologger "github.com/giantswarm/microkit/logger"
 
 	"github.com/giantswarm/draughtsman/flag"
+	"github.com/giantswarm/draughtsman/service/deployer/installer/configurer"
+	configurerspec "github.com/giantswarm/draughtsman/service/deployer/installer/configurer/spec"
 	"github.com/giantswarm/draughtsman/service/deployer/installer/helm"
 	"github.com/giantswarm/draughtsman/service/deployer/installer/spec"
 )
@@ -53,6 +55,23 @@ func New(config Config) (spec.Installer, error) {
 
 	var err error
 
+	var configurerService configurerspec.Configurer
+	{
+		configurerConfig := configurer.DefaultConfig()
+
+		configurerConfig.Logger = config.Logger
+
+		configurerConfig.Flag = config.Flag
+		configurerConfig.Viper = config.Viper
+
+		configurerConfig.Type = configurerspec.ConfigurerType(config.Viper.GetString(config.Flag.Service.Deployer.Installer.Configurer.Type))
+
+		configurerService, err = configurer.New(configurerConfig)
+		if err != nil {
+			return nil, microerror.MaskAny(err)
+		}
+	}
+
 	var newInstaller spec.Installer
 
 	switch config.Type {
@@ -60,6 +79,7 @@ func New(config Config) (spec.Installer, error) {
 		helmConfig := helm.DefaultConfig()
 
 		helmConfig.Logger = config.Logger
+		helmConfig.Configurer = configurerService
 
 		helmConfig.HelmBinaryPath = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Helm.HelmBinaryPath)
 		helmConfig.Organisation = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Helm.Organisation)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1253

This PR adds the concept of a `Configurer`, which is a service that is responsible for providing a values file to the installer, for Helm to use for templating.

We also add a `FileConfigurer`, which is a `Configurer` that uses a simple file to provide the values.

In future, we can use a configmap to hold the configuration data, or back it with a git repository. I'm leaning towards configmap for the near future, and then git repository in the further future.