### PR TITLE
Fixes incorrect failed state string

### DIFF
--- a/service/deployer/eventer/github/client_test.go
+++ b/service/deployer/eventer/github/client_test.go
@@ -106,7 +106,7 @@ func TestFilterDeploymentsByStatus(t *testing.T) {
 			deployments: []deployment{
 				deployment{
 					Statuses: []deploymentStatus{
-						deploymentStatus{State: failedState},
+						deploymentStatus{State: failureState},
 					},
 				},
 			},
@@ -132,7 +132,7 @@ func TestFilterDeploymentsByStatus(t *testing.T) {
 				deployment{
 					Statuses: []deploymentStatus{
 						deploymentStatus{State: pendingState},
-						deploymentStatus{State: failedState},
+						deploymentStatus{State: failureState},
 					},
 				},
 			},

--- a/service/deployer/eventer/github/github.go
+++ b/service/deployer/eventer/github/github.go
@@ -124,5 +124,5 @@ func (e *GithubEventer) SetSuccess(event spec.DeploymentEvent) error {
 }
 
 func (e *GithubEventer) SetFailed(event spec.DeploymentEvent) error {
-	return e.postDeploymentStatus(event.Name, event.ID, failedState)
+	return e.postDeploymentStatus(event.Name, event.ID, failureState)
 }

--- a/service/deployer/eventer/github/spec.go
+++ b/service/deployer/eventer/github/spec.go
@@ -44,6 +44,6 @@ var (
 	pendingState deploymentStatusState = "pending"
 	// successState is the state for successful Deployment Status states.
 	successState deploymentStatusState = "success"
-	// failedState is the state for failed Deployment Status states.
-	failedState deploymentStatusState = "failed"
+	// failureState is the state for failed Deployment Status states.
+	failureState deploymentStatusState = "failure"
 )


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1253

From docs:
```
state - Required. The state of the status. Can be one of pending, success, error, inactive, or failure
```
Using `failed` instead of `failure` causes the GitHub api to complain, because we're not matching the API.




I am aware of the irony here.