### PR TITLE
Adds error string in case helm exits erroneously

### DIFF
--- a/service/deployer/installer/helm/helm.go
+++ b/service/deployer/installer/helm/helm.go
@@ -152,7 +152,7 @@ func (i *HelmInstaller) runHelmCommand(name string, args ...string) error {
 	)
 
 	if err != nil {
-		return microerror.MaskAny(err)
+		return microerror.MaskAnyf(err, stdErrBuf.String())
 	}
 
 	if strings.Contains(stdOutBuf.String(), "Error") {


### PR DESCRIPTION
Fixes https://github.com/giantswarm/draughtsman/issues/16

e.g
i shut down the tiller pod, to force a helm error

without change:
<img width="606" alt="screen shot 2017-06-09 at 18 02 55" src="https://user-images.githubusercontent.com/297653/26986085-f791cd94-4d3d-11e7-8afe-6e0c7c0c4c1a.png">

with change:
<img width="625" alt="screen shot 2017-06-09 at 18 02 07" src="https://user-images.githubusercontent.com/297653/26986097-feba9b82-4d3d-11e7-9657-88b07c676421.png">

which is much more useful :D