### PR TITLE
Fixes bad comma separated list handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func main() {
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Eventer.GitHub.OAuthToken, "", "OAuth token for authenticating against GitHub. Needs 'repo_deployment' scope.")
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Eventer.GitHub.Organisation, "", "Organisation under which to check for deployments.")
 	daemonCommand.PersistentFlags().Duration(f.Service.Deployer.Eventer.GitHub.PollInterval, 1*time.Minute, "Interval to poll for new deployments.")
-	daemonCommand.PersistentFlags().StringSlice(f.Service.Deployer.Eventer.GitHub.ProjectList, []string{}, "List of GitHub projects to check for deployments.")
+	daemonCommand.PersistentFlags().String(f.Service.Deployer.Eventer.GitHub.ProjectList, "", "Comma seperated list of GitHub projects to check for deployments.")
 
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Helm.HelmBinaryPath, "/bin/helm", "Path to Helm binary. Needs CNR registry plugin installed.")
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Helm.Organisation, "", "Organisation of Helm CNR registry.")

--- a/service/deployer/eventer/eventer.go
+++ b/service/deployer/eventer/eventer.go
@@ -1,6 +1,8 @@
 package eventer
 
 import (
+	"strings"
+
 	"github.com/spf13/viper"
 
 	microerror "github.com/giantswarm/microkit/error"
@@ -63,7 +65,9 @@ func New(config Config) (spec.Eventer, error) {
 		githubConfig.OAuthToken = config.Viper.GetString(config.Flag.Service.Deployer.Eventer.GitHub.OAuthToken)
 		githubConfig.Organisation = config.Viper.GetString(config.Flag.Service.Deployer.Eventer.GitHub.Organisation)
 		githubConfig.PollInterval = config.Viper.GetDuration(config.Flag.Service.Deployer.Eventer.GitHub.PollInterval)
-		githubConfig.ProjectList = config.Viper.GetStringSlice(config.Flag.Service.Deployer.Eventer.GitHub.ProjectList)
+
+		projectList := config.Viper.GetString(config.Flag.Service.Deployer.Eventer.GitHub.ProjectList)
+		githubConfig.ProjectList = strings.Split(projectList, ",")
 
 		newEventer, err = github.New(githubConfig)
 		if err != nil {


### PR DESCRIPTION
When we supply the project list via the configuration file, the string is not properly split by commas. This changeset handles the separation ourselves.