### PR TITLE
Removes namespace from helm chart

### DIFF
--- a/helm/draughtsman-chart/templates/namespace.yaml
+++ b/helm/draughtsman-chart/templates/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: draughtsman
-  labels:
-    app: draughtsman


### PR DESCRIPTION
When bootstrapping, we want to install the release into the
draughtsman namespace, so we need to create it ourselves.
If the namespace exists as part of the helm chart, we can't install
the chart into the namespace, because it conflicts.