### PR TITLE
use proper naming for ConfigMap

### DIFF
--- a/flag/service/deployer/installer/configurer/configmap/configmap.go
+++ b/flag/service/deployer/installer/configurer/configmap/configmap.go
@@ -1,6 +1,6 @@
 package configmap
 
-type Configmap struct {
+type ConfigMap struct {
 	Key       string
 	Name      string
 	Namespace string

--- a/flag/service/deployer/installer/configurer/configurer.go
+++ b/flag/service/deployer/installer/configurer/configurer.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Configurer struct {
-	Configmap configmap.Configmap
+	ConfigMap configmap.ConfigMap
 	File      file.File
 	Secret    secret.Secret
 	Type      string

--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ func main() {
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Type, string(deployer.StandardDeployer), "Which deployer to use for deployment management.")
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Eventer.Type, string(github.GithubEventerType), "Which eventer to use for event management.")
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Type, string(helm.HelmInstallerType), "Which installer to use for installation management.")
-	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Configurer.Type, string(configmap.ConfigmapConfigurerType), "Which configurer to use for configuration management.")
+	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Configurer.Type, string(configmap.ConfigMapConfigurerType), "Which configurer to use for configuration management.")
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Notifier.Type, string(slacknotifier.SlackNotifierType), "Which notifier to use for notification management.")
 
 	// Client configuration.
@@ -182,9 +182,9 @@ func main() {
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Helm.Registry, "quay.io", "URL for Helm CNR registry.")
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Helm.Username, "", "Username for Helm CNR registry.")
 
-	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Configurer.Configmap.Key, "values", "Key in configmap holding values data.")
-	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Configurer.Configmap.Name, "draughtsman-values", "Name of configmap holding values data.")
-	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Configurer.Configmap.Namespace, "draughtsman", "Namespace of configmap holding values data.")
+	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Configurer.ConfigMap.Key, "values", "Key in configmap holding values data.")
+	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Configurer.ConfigMap.Name, "draughtsman-values", "Name of configmap holding values data.")
+	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Configurer.ConfigMap.Namespace, "draughtsman", "Namespace of configmap holding values data.")
 
 	daemonCommand.PersistentFlags().String(f.Service.Deployer.Installer.Configurer.File.Path, "", "Path to values file.")
 

--- a/service/configurer/configmap/configmap.go
+++ b/service/configurer/configmap/configmap.go
@@ -14,11 +14,11 @@ import (
 	"github.com/giantswarm/draughtsman/service/configurer/spec"
 )
 
-// ConfigmapConfigurerType is a Configurer that is backed by a Kubernetes
-// Configmap.
-var ConfigmapConfigurerType spec.ConfigurerType = "ConfigmapConfigurer"
+// ConfigMapConfigurerType is a Configurer that is backed by a Kubernetes
+// ConfigMap.
+var ConfigMapConfigurerType spec.ConfigurerType = "ConfigMapConfigurer"
 
-// Config represents the configuration used to create a Configmap Configurer.
+// Config represents the configuration used to create a ConfigMap Configurer.
 type Config struct {
 	// Dependencies.
 	KubernetesClient kubernetes.Interface
@@ -31,7 +31,7 @@ type Config struct {
 	Namespace string
 }
 
-// DefaultConfig provides a default configuration to create a new Configmap
+// DefaultConfig provides a default configuration to create a new ConfigMap
 // Configurer by best effort.
 func DefaultConfig() Config {
 	return Config{
@@ -41,8 +41,8 @@ func DefaultConfig() Config {
 	}
 }
 
-// New creates a new configured Configmap Configurer.
-func New(config Config) (*ConfigmapConfigurer, error) {
+// New creates a new configured ConfigMap Configurer.
+func New(config Config) (*ConfigMapConfigurer, error) {
 	if config.KubernetesClient == nil {
 		return nil, microerror.MaskAnyf(invalidConfigError, "kubernetes client must not be empty")
 	}
@@ -71,7 +71,7 @@ func New(config Config) (*ConfigmapConfigurer, error) {
 		return nil, microerror.MaskAny(err)
 	}
 
-	configurer := &ConfigmapConfigurer{
+	configurer := &ConfigMapConfigurer{
 		// Dependencies.
 		client: config.KubernetesClient,
 		logger: config.Logger,
@@ -86,9 +86,9 @@ func New(config Config) (*ConfigmapConfigurer, error) {
 	return configurer, nil
 }
 
-// ConfigmapConfigurer is an implementation of the Configurer interface,
-// that uses a Kubernetes Configmap to hold configuration.
-type ConfigmapConfigurer struct {
+// ConfigMapConfigurer is an implementation of the Configurer interface,
+// that uses a Kubernetes ConfigMap to hold configuration.
+type ConfigMapConfigurer struct {
 	// Dependencies.
 	client kubernetes.Interface
 	logger micrologger.Logger
@@ -100,8 +100,8 @@ type ConfigmapConfigurer struct {
 	tempFile  *os.File
 }
 
-func (c *ConfigmapConfigurer) File() (string, error) {
-	defer updateConfigmapMetrics(time.Now())
+func (c *ConfigMapConfigurer) File() (string, error) {
+	defer updateConfigMapMetrics(time.Now())
 
 	c.logger.Log("debug", "fetching configuration from configmap", "name", c.name, "namespace", c.namespace)
 

--- a/service/configurer/configmap/metrics.go
+++ b/service/configurer/configmap/metrics.go
@@ -22,7 +22,7 @@ var (
 			Namespace: prometheusNamespace,
 			Subsystem: prometheusSubsystem,
 			Name:      "request_duration_milliseconds",
-			Help:      "Time taken to request Configmap manifests from Kubernetes.",
+			Help:      "Time taken to request ConfigMap manifests from Kubernetes.",
 		},
 	)
 	requestTotal = prometheus.NewCounter(
@@ -30,7 +30,7 @@ var (
 			Namespace: prometheusNamespace,
 			Subsystem: prometheusSubsystem,
 			Name:      "request_total",
-			Help:      "Number of requests to fetch Configmap manifests from Kubernetes.",
+			Help:      "Number of requests to fetch ConfigMap manifests from Kubernetes.",
 		},
 	)
 )
@@ -40,7 +40,7 @@ func init() {
 	prometheus.MustRegister(requestTotal)
 }
 
-func updateConfigmapMetrics(startTime time.Time) {
+func updateConfigMapMetrics(startTime time.Time) {
 	requestDuration.Set(float64(time.Since(startTime) / time.Millisecond))
 	requestTotal.Inc()
 }

--- a/service/configurer/configurer.go
+++ b/service/configurer/configurer.go
@@ -55,15 +55,15 @@ func New(config Config) (spec.Configurer, error) {
 
 	var newConfigurer spec.Configurer
 	switch config.Type {
-	case configmap.ConfigmapConfigurerType:
+	case configmap.ConfigMapConfigurerType:
 		configmapConfig := configmap.DefaultConfig()
 
 		configmapConfig.KubernetesClient = config.KubernetesClient
 		configmapConfig.Logger = config.Logger
 
-		configmapConfig.Key = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Configurer.Configmap.Key)
-		configmapConfig.Name = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Configurer.Configmap.Name)
-		configmapConfig.Namespace = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Configurer.Configmap.Namespace)
+		configmapConfig.Key = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Configurer.ConfigMap.Key)
+		configmapConfig.Name = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Configurer.ConfigMap.Name)
+		configmapConfig.Namespace = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Configurer.ConfigMap.Namespace)
 
 		newConfigurer, err = configmap.New(configmapConfig)
 		if err != nil {


### PR DESCRIPTION
This PR renames `Configmap` to `ConfigMap` since this is the official wording. See https://kubernetes.io/docs/tasks/configure-pod-container/configmap/. 