### PR TITLE
Add curl to image and download plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 
 RUN apt-get -y update \
     && apt-get -y install \
-    wget
+    curl wget
 
 RUN wget https://storage.googleapis.com/kubernetes-helm/helm-v2.6.2-linux-amd64.tar.gz -qO- | tar xzf - linux-amd64/helm \
     && chmod +x ./linux-amd64/helm \
@@ -11,7 +11,8 @@ RUN wget https://storage.googleapis.com/kubernetes-helm/helm-v2.6.2-linux-amd64.
 
 RUN mkdir -p ~/.helm/plugins/ \
     && wget https://github.com/app-registry/appr-helm-plugin/releases/download/v0.5.1/registry-helm-plugin.tar.gz -qO- | tar xzf - registry \
-    && mv ./registry ~/.helm/plugins/
+    && mv ./registry ~/.helm/plugins/ \
+    && ~/.helm/plugins/registry/cnr.sh upgrade-plugin
 
 ADD draughtsman /
 


### PR DESCRIPTION
1) Updated cnr.sh script relies on curl, so install it
2) Script cnr.sh every time downloads appr binary.
   So download it while image build, to prevent downloading
   on every :older_man: start.

outcomes of https://github.com/giantswarm/draughtsman/commit/392bb666d81183c89d3eb2aab7ee9c9f8237c7bd