### PR TITLE
Updates related to new rgistry plugin

### DIFF
--- a/helm/draughtsman-chart/templates/deployment.yaml
+++ b/helm/draughtsman-chart/templates/deployment.yaml
@@ -52,9 +52,9 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 100Mi
+            memory: 150Mi
           limits:
             cpu: 100m
-            memory: 100Mi
+            memory: 150Mi
       imagePullSecrets:
       - name: draughtsman-pull-secret

--- a/service/installer/helm/helm_test.go
+++ b/service/installer/helm/helm_test.go
@@ -39,21 +39,21 @@ func TestVersionedChartName(t *testing.T) {
 	}
 }
 
-// TestTarballName tests the tarballName method.
-func TestTarballName(t *testing.T) {
+// TestChartName tests the chartName method.
+func TestChartName(t *testing.T) {
 	tests := []struct {
-		registry            string
-		organisation        string
-		project             string
-		sha                 string
-		expectedTarballName string
+		registry          string
+		organisation      string
+		project           string
+		sha               string
+		expectedChartName string
 	}{
 		{
-			registry:            "quay.io",
-			organisation:        "giantswarm",
-			project:             "api",
-			sha:                 "12345",
-			expectedTarballName: "giantswarm_api-chart_1.0.0-12345.tar.gz",
+			registry:          "quay.io",
+			organisation:      "giantswarm",
+			project:           "api",
+			sha:               "12345",
+			expectedChartName: "giantswarm_api-chart_1.0.0-12345/api-chart",
 		},
 	}
 
@@ -63,12 +63,12 @@ func TestTarballName(t *testing.T) {
 			organisation: test.organisation,
 		}
 
-		returnedTarballName := i.tarballName(test.project, test.sha)
+		returnedChartName := i.chartName(test.project, test.sha)
 
-		if returnedTarballName != test.expectedTarballName {
+		if returnedChartName != test.expectedChartName {
 			t.Fatalf(
 				"%v\nexpected: %#v\nreturned: %#v\n",
-				index, test.expectedTarballName, returnedTarballName,
+				index, test.expectedChartName, returnedChartName,
 			)
 		}
 	}


### PR DESCRIPTION
Tested on `gauss` (including installation of charts) and manually released this version to all environments (except lycan, as no access now).

After this will be merged it automatically should release itself.

1) charts are folders not tarballs in registry plugin 0.5.1
2) increase memory limit to prevent CrashLoops

Following errors related to 2.
```
  1 {"caller":"github.com/giantswarm/draughtsman/service/installer/helm/helm.go:192","debug":"logging into registry","registry":"quay.io","time":    "17-10-12 19:02:52.657","username":"giantswarm+gauss"}
  2 {"caller":"github.com/giantswarm/draughtsman/service/installer/helm/helm.go:162","debug":"running helm command","name":"login","time":"17-10-    12 19:02:52.657"}
  3 {"caller":"github.com/giantswarm/draughtsman/service/installer/helm/helm.go:174","debug":"ran helm command","name":"login","stderr":"Failed t    o write all bytes for libX11.so.6\nfwrite: Cannot allocate memory\nError: plugin \"registry\" exited with error\n","stdout":"","time":"17-10-    12 19:02:58.473"}
  4 panic: exit status 1: Failed to write all bytes for libX11.so.6
  5 fwrite: Cannot allocate memory
  6 Error: plugin "registry" exited with error
  7 
  8 
  9 {"caller":"github.com/giantswarm/draughtsman/service/installer/helm/helm.go:192","debug":"logging into registry","registry":"quay.io","time":    "17-10-12 19:12:57.577","username":"giantswarm+gauss"}
 10 {"caller":"github.com/giantswarm/draughtsman/service/installer/helm/helm.go:162","debug":"running helm command","name":"login","time":"17-10-    12 19:12:57.577"}
 11 {"caller":"github.com/giantswarm/draughtsman/service/installer/helm/helm.go:174","debug":"ran helm command","name":"login","stderr":"Failed t    o write all bytes for libcrypto.so.1.0.0\nfwrite: Cannot allocate memory\nError: plugin \"registry\" exited with error\n","stdout":"","time":    "17-10-12 19:13:03.470"}
 12 panic: exit status 1: Failed to write all bytes for libcrypto.so.1.0.0
 13 fwrite: Cannot allocate memory
 14 Error: plugin "registry" exited with error

```