### PR TITLE
Add rbac and psp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,14 @@ RUN set -x \
     && mkdir -p /home/draughtsman/.helm/plugins \
     && curl -L -s https://github.com/app-registry/appr-helm-plugin/releases/download/v$APPR_PLUGIN_VERSION/helm-registry_linux.tar.gz | tar xvzf - registry \
     && mv ./registry /home/draughtsman/.helm/plugins/registry \
-    && /home/draughtsman/.helm/plugins/registry/cnr.sh upgrade-plugin \
-    && chmod 755 -R /home/draughtsman/.helm \
-    && helm registry --help > /dev/null
+    && chown -R draughtsman:draughtsman /home/draughtsman/.helm
 
 ADD draughtsman /
 
 USER draughtsman
+
+RUN cd /home/draughtsman/.helm/plugins/registry \
+    && ./cnr.sh upgrade-plugin \
+    && helm registry --help > /dev/null
 
 ENTRYPOINT ["/draughtsman"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV HELM_VERSION 2.6.2
 ENV APPR_PLUGIN_VERSION 0.7.0
 
 # add application user
-RUN addgroup -S app && adduser -S -g draughtsman draughtsman
+RUN addgroup -S draughtsman && adduser -S -g draughtsman draughtsman
 
 # dependencies
 RUN set -x \
@@ -19,14 +19,15 @@ RUN set -x \
 
 # install helm appr (registry) plugin
 RUN set -x \
-    && mkdir -p ~/.helm/plugins \
+    && mkdir -p /home/draughtsman/.helm/plugins \
     && curl -L -s https://github.com/app-registry/appr-helm-plugin/releases/download/v$APPR_PLUGIN_VERSION/helm-registry_linux.tar.gz | tar xvzf - registry \
-    && mv ./registry ~/.helm/plugins/registry \
-    && ~/.helm/plugins/registry/cnr.sh upgrade-plugin \
-    && helm registry --help
+    && mv ./registry /home/draughtsman/.helm/plugins/registry \
+    && /home/draughtsman/.helm/plugins/registry/cnr.sh upgrade-plugin \
+    && chmod 755 -R /home/draughtsman/.helm \
+    && helm registry --help > /dev/null
 
 ADD draughtsman /
 
 USER draughtsman
 
-ENTRYPOINT ["sh"]
+ENTRYPOINT ["/draughtsman"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ RUN set -x \
     && curl -L -s https://github.com/app-registry/appr-helm-plugin/releases/download/v$APPR_PLUGIN_VERSION/helm-registry_linux.tar.gz | tar xvzf - registry \
     && mv ./registry ~/.helm/plugins/registry \
     && ~/.helm/plugins/registry/cnr.sh upgrade-plugin \
-    && helm registry --help >> /dev/null
+    && helm registry --help
 
 ADD draughtsman /
 
 USER draughtsman
 
-ENTRYPOINT ["/draughtsman"]
+ENTRYPOINT ["sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,14 @@ RUN set -x \
     && mv ./registry /home/draughtsman/.helm/plugins/registry \
     && chown -R draughtsman:draughtsman /home/draughtsman/.helm
 
-ADD draughtsman /
-
 USER draughtsman
+
+ADD draughtsman /home/draughtsman/
 
 RUN cd /home/draughtsman/.helm/plugins/registry \
     && ./cnr.sh upgrade-plugin \
     && helm registry --help > /dev/null
 
-ENTRYPOINT ["/draughtsman"]
+WORKDIR /home/draughtsman
+
+ENTRYPOINT ["/home/draughtsman/draughtsman"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM alpine:3.6
 ENV HELM_VERSION 2.6.2
 ENV APPR_PLUGIN_VERSION 0.7.0
 
+# add application user
+RUN addgroup -S app && adduser -S -g draughtsman draughtsman
+
 # dependencies
 RUN set -x \
     && apk update && apk --no-cache add ca-certificates openssl curl bash zlib
@@ -23,5 +26,7 @@ RUN set -x \
     && helm registry --help >> /dev/null
 
 ADD draughtsman /
+
+USER draughtsman
 
 ENTRYPOINT ["/draughtsman"]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -65,7 +65,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/giantswarm/microstorage"
-  packages = ["."]
+  packages = [".","memory"]
   revision = "99418478ec8f5c68f9b5fc5e6be7e0474948f80d"
 
 [[projects]]
@@ -308,6 +308,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1a08fc0d660f3694111fba350410cfbbd16339e68b5fa2e514f9334af6639054"
+  inputs-digest = "de7f08a7fd51d24c13a9702507f93ba99af5eee2b87ff53961eafc474a355f14"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -71,3 +71,34 @@ data:
 ```
 
 All data under the `values` key (by default), is passed verbatim to Helm, to provide values for chart Installations.
+
+# Helm and RBAC
+
+Draughtsman uses helm as packager manager to deploy and manage the applications in the cluster. In latest kubernetes versions, RBAC (Role-Based Access Control) is enable by default. In that case helm will need a cluster role and service account to work properly.
+
+```
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system
+```
+
+Furtherly, helm should be installed using the flag service account set to tiller.
+
+```
+helm init --service-account tiller
+```

--- a/helm/draughtsman-chart/templates/deployment.yaml
+++ b/helm/draughtsman-chart/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       - name: secret
         secret:
           secretName: draughtsman
+      serviceAccountName: draughtsman
       containers:
       - name: draughtsman
         image: quay.io/giantswarm/draughtsman:[[ .SHA ]]

--- a/helm/draughtsman-chart/templates/psp.yaml
+++ b/helm/draughtsman-chart/templates/psp.yaml
@@ -6,7 +6,8 @@ spec:
   # not allow manage devices
   privileged: false
   # prevent setuid binaries from changing the effective user ID
-  allowPrivilegeEscalation: false
+  # UNCOMMENT WHEN WE MOVE TO 1.8 
+  # allowPrivilegeEscalation: false
   # drop all capabailities from the underneath container
   requiredDropCapabilities:
     - ALL
@@ -19,6 +20,9 @@ spec:
   # process IPC/ID namespace not shared
   hostIPC: false
   hostPID: false
+  # No default settings provided
+  seLinux:
+    rule: RunAsAny
   # User and group should not be root
   runAsUser:
     rule: 'MustRunAs'

--- a/helm/draughtsman-chart/templates/psp.yaml
+++ b/helm/draughtsman-chart/templates/psp.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: draughtsman-psp
+spec:
+  # not allow manage devices
+  privileged: false
+  # prevent setuid binaries from changing the effective user ID
+  allowPrivilegeEscalation: false
+  # drop all capabailities from the underneath container
+  requiredDropCapabilities:
+    - ALL
+  # only allow
+  volumes:
+    - 'configMap'
+    - 'secret'
+  # not able to user host network namespace
+  hostNetwork: false
+  # process IPC/ID namespace not shared
+  hostIPC: false
+  hostPID: false
+  # User and group should not be root
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535

--- a/helm/draughtsman-chart/templates/rbac.yaml
+++ b/helm/draughtsman-chart/templates/rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: draughtsman
+  namespace: draughtsman
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmap
+      - secrets
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: draughtsman
+subjects:
+  - kind: ServiceAccount
+    name: draughtsman
+    namespace: draughtsman
+roleRef:
+  kind: Role
+  name: draughtsman
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/draughtsman-chart/templates/rbac.yaml
+++ b/helm/draughtsman-chart/templates/rbac.yaml
@@ -26,3 +26,30 @@ roleRef:
   kind: Role
   name: draughtsman
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: draughtsman-psp
+rules:
+  - apiGroups:
+    - extensions
+  resources:
+    - podsecuritypolicies
+  verbs:
+    - use
+  resourceNames:
+    - draughtsman-psp
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: draughtsman-psp
+roleRef:
+  kind: ClusterRole
+  name: draughtsman-psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: draughtsman
+  namespace: draughtsman

--- a/helm/draughtsman-chart/templates/rbac.yaml
+++ b/helm/draughtsman-chart/templates/rbac.yaml
@@ -2,17 +2,44 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: draughtsman
-  namespace: draughtsman
 rules:
   - apiGroups:
       - ""
     resources:
       - configmaps
+    resourceNames:
+      - draughtsman
+      - draughtsman-values-configmap
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
       - secrets
     resourceNames:
       - draughtsman
+      - draughtsman-pull-secret
+      - draughtsman-values-secret
     verbs:
       - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: draughtsman-tiller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/portforward
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -26,6 +53,20 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: draughtsman
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: draughtsman-tiller
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: draughtsman
+    namespace: draughtsman
+roleRef:
+  kind: ClusterRole
+  name: draughtsman-tiller
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/helm/draughtsman-chart/templates/rbac.yaml
+++ b/helm/draughtsman-chart/templates/rbac.yaml
@@ -13,14 +13,6 @@ rules:
       - draughtsman
     verbs:
       - get
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    resourceNames:
-      - draughtsman
-    verbs:
-      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/helm/draughtsman-chart/templates/rbac.yaml
+++ b/helm/draughtsman-chart/templates/rbac.yaml
@@ -18,6 +18,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: draughtsman
+  namespace: draughtsman
 subjects:
   - kind: ServiceAccount
     name: draughtsman

--- a/helm/draughtsman-chart/templates/rbac.yaml
+++ b/helm/draughtsman-chart/templates/rbac.yaml
@@ -18,7 +18,7 @@ rules:
     resources:
       - namespaces
     resourceNames:
-      - default
+      - draughtsman
     verbs:
       - get
 ---
@@ -31,7 +31,7 @@ subjects:
     name: draughtsman
     namespace: draughtsman
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: draughtsman
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/helm/draughtsman-chart/templates/rbac.yaml
+++ b/helm/draughtsman-chart/templates/rbac.yaml
@@ -9,6 +9,8 @@ rules:
     resources:
       - configmap
       - secrets
+    resourceNames:
+      - draughtsman
     verbs:
       - get
 ---

--- a/helm/draughtsman-chart/templates/rbac.yaml
+++ b/helm/draughtsman-chart/templates/rbac.yaml
@@ -35,7 +35,7 @@ roleRef:
   name: draughtsman
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: draughtsman-psp
@@ -49,7 +49,7 @@ rules:
     resourceNames:
       - draughtsman-psp
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: draughtsman-psp

--- a/helm/draughtsman-chart/templates/rbac.yaml
+++ b/helm/draughtsman-chart/templates/rbac.yaml
@@ -35,29 +35,29 @@ roleRef:
   name: draughtsman
   apiGroup: rbac.authorization.k8s.io
 ---
-kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
   name: draughtsman-psp
 rules:
   - apiGroups:
-    - extensions
-  resources:
-    - podsecuritypolicies
-  verbs:
-    - use
-  resourceNames:
-    - draughtsman-psp
+      - extensions
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - draughtsman-psp
 ---
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: draughtsman-psp
+subjects:
+  - kind: ServiceAccount
+    name: draughtsman
+    namespace: draughtsman
 roleRef:
   kind: ClusterRole
   name: draughtsman-psp
   apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: draughtsman
-  namespace: draughtsman

--- a/helm/draughtsman-chart/templates/rbac.yaml
+++ b/helm/draughtsman-chart/templates/rbac.yaml
@@ -15,6 +15,13 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - namespaces
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - ""
+    resources:
       - secrets
     resourceNames:
       - draughtsman
@@ -22,6 +29,19 @@ rules:
       - draughtsman-values-secret
     verbs:
       - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: draughtsman
+subjects:
+  - kind: ServiceAccount
+    name: draughtsman
+    namespace: draughtsman
+roleRef:
+  kind: ClusterRole
+  name: draughtsman
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -40,20 +60,6 @@ rules:
       - pods/portforward
     verbs:
       - create
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: draughtsman
-  namespace: draughtsman
-subjects:
-  - kind: ServiceAccount
-    name: draughtsman
-    namespace: draughtsman
-roleRef:
-  kind: ClusterRole
-  name: draughtsman
-  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/helm/draughtsman-chart/templates/rbac.yaml
+++ b/helm/draughtsman-chart/templates/rbac.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
+kind: ClusterRole
 metadata:
   name: draughtsman
   namespace: draughtsman
@@ -7,10 +7,18 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmap
+      - configmaps
       - secrets
     resourceNames:
       - draughtsman
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    resourceNames:
+      - default
     verbs:
       - get
 ---

--- a/helm/draughtsman-chart/templates/service-account.yaml
+++ b/helm/draughtsman-chart/templates/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: draughtsman
+  namespace: draughtsman

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	// We define a server factory to create the custom server once all command
-	// line flags are parsed and all microservice configuration is storted out.
+	// line flags are parsed and all microservice configuration is sorted out.
 	newServerFactory := func(v *viper.Viper) microserver.Server {
 		var newHttpClient *http.Client
 		{

--- a/service/configurer/configmap/configmap.go
+++ b/service/configurer/configmap/configmap.go
@@ -67,7 +67,7 @@ func New(config Config) (*ConfigMapConfigurer, error) {
 	}
 
 	config.Logger.Log("debug", "checking connection to Kubernetes")
-	if _, err := config.KubernetesClient.CoreV1().Namespaces().Get("draughtsman", v1.GetOptions{}); err != nil {
+	if _, err := config.KubernetesClient.CoreV1().ConfigMaps("draughtsman").Get("draughtsman", v1.GetOptions{}); err != nil {
 		return nil, microerror.Mask(err)
 	}
 

--- a/service/configurer/configmap/configmap.go
+++ b/service/configurer/configmap/configmap.go
@@ -67,7 +67,7 @@ func New(config Config) (*ConfigMapConfigurer, error) {
 	}
 
 	config.Logger.Log("debug", "checking connection to Kubernetes")
-	if _, err := config.KubernetesClient.CoreV1().Namespaces().Get("default", v1.GetOptions{}); err != nil {
+	if _, err := config.KubernetesClient.CoreV1().Namespaces().Get("draughtsman", v1.GetOptions{}); err != nil {
 		return nil, microerror.Mask(err)
 	}
 

--- a/service/configurer/secret/secret.go
+++ b/service/configurer/secret/secret.go
@@ -67,7 +67,7 @@ func New(config Config) (*SecretConfigurer, error) {
 	}
 
 	config.Logger.Log("debug", "checking connection to Kubernetes")
-	_, err := config.KubernetesClient.CoreV1().Namespaces().Get("default", v1.GetOptions{})
+	_, err := config.KubernetesClient.CoreV1().Namespaces().Get("draughtsman", v1.GetOptions{})
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/configurer/secret/secret.go
+++ b/service/configurer/secret/secret.go
@@ -67,7 +67,7 @@ func New(config Config) (*SecretConfigurer, error) {
 	}
 
 	config.Logger.Log("debug", "checking connection to Kubernetes")
-	_, err := config.KubernetesClient.CoreV1().Namespaces().Get("draughtsman", v1.GetOptions{})
+	_, err := config.KubernetesClient.CoreV1().Secrets("draughtsman").Get("draughtsman", v1.GetOptions{})
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}


### PR DESCRIPTION
Towards [#2296](https://github.com/giantswarm/giantswarm/issues/2296)

I have added a service account and a role with the k8s methods I have seen our code uses.

The role is at the namespace level because I understand draughtsman only reads config map in the same space it is and applies the changes. I have seen is using the helm installed client to apply the changes, but how do we install the helm client in the host?
Right now all system authenticated users have PSP restricted. So I do think any special PSP should be applied to draughtsman, but helm client which is the one could need more privileges, WDYT?

cc/ @puja108 