### PR TITLE
Remove --recreate-pods from helm Install command.

### DIFF
--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -273,7 +273,7 @@ func (i *HelmInstaller) Install(event eventerspec.DeploymentEvent) error {
 	//
 	var installCommand []string
 	{
-		installCommand = append(installCommand, "upgrade", "--install", "--recreate-pods")
+		installCommand = append(installCommand, "upgrade", "--install")
 		installCommand = append(installCommand, valuesFilesArgs...)
 		installCommand = append(installCommand, project, chartPath)
 


### PR DESCRIPTION
This flag restarts all pods immediately on deploy. The consequence is
that we do not get zero down time deploys.

See for more discussion: https://github.com/giantswarm/giantswarm/issues/3366