### PR TITLE
Vendor helmclient

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -80,7 +80,7 @@
   branch = "master"
   name = "github.com/giantswarm/helmclient"
   packages = ["."]
-  revision = "e8092ab19d09971015553fc30731ff752e6abdd0"
+  revision = "d3a2f6ea23b4bb0e11503fde0f72b03aac726515"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/giantswarm/helmclient/helmclient_test.go
+++ b/vendor/github.com/giantswarm/helmclient/helmclient_test.go
@@ -604,7 +604,7 @@ func Test_isTillerOutdated(t *testing.T) {
 			errorMatcher: IsTillerOutdated,
 		},
 		{
-			name: "case 4: tiller image has no version tag",
+			name: "case 4: tiller image has no version tag so we upgrade",
 			tillerPod: &corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -614,10 +614,23 @@ func Test_isTillerOutdated(t *testing.T) {
 					},
 				},
 			},
-			errorMatcher: IsExecutionFailed,
+			errorMatcher: IsTillerOutdated,
 		},
 		{
-			name: "case 5: tiller image tag format is invalid",
+			name: "case 5: tiller image uses latest tag so we upgrade",
+			tillerPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Image: "quay.io/giantswarm/tiller:latest",
+						},
+					},
+				},
+			},
+			errorMatcher: IsTillerOutdated,
+		},
+		{
+			name: "case 6: tiller image tag format is invalid",
 			tillerPod: &corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -630,7 +643,7 @@ func Test_isTillerOutdated(t *testing.T) {
 			errorMatcher: IsExecutionFailed,
 		},
 		{
-			name: "case 6: tiller image tag format is invalid",
+			name: "case 7: tiller image tag format is invalid",
 			tillerPod: &corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{


### PR DESCRIPTION
Deploys fix for when tiller image has been changed manually. draughtsman will upgrade it to the version specified in helmclient (currently v2.12.0).