### PR TITLE
Add network policy

### DIFF
--- a/helm/draughtsman-chart/templates/deployment.yaml
+++ b/helm/draughtsman-chart/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: draughtsman
       containers:
       - name: draughtsman
-        image: quay.io/giantswarm/draughtsman:[[ .SHA ]]
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         args:
         - "daemon"
         - "--config.dirs=/var/run/draughtsman/configmap/"

--- a/helm/draughtsman-chart/templates/network-policy.yaml
+++ b/helm/draughtsman-chart/templates/network-policy.yaml
@@ -1,0 +1,24 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: {{ .Values.resource.default.namespace }}
+  name: {{ .Values.resource.default.name }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Values.resource.default.name }}
+  ingress:
+  - ports:
+    - port: {{ .Values.ports.draughtsman.name }}
+      protocol: {{ .Values.ports.draughtsman.protocol }}
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.0.0.0/8
+    - ipBlock:
+        cidr: 172.16.0.0/12
+    - ipBlock:
+        cidr: 192.168.0.0/16
+  policyTypes:
+  - Egress
+  - Ingress

--- a/helm/draughtsman-chart/templates/network-policy.yaml
+++ b/helm/draughtsman-chart/templates/network-policy.yaml
@@ -12,13 +12,7 @@ spec:
     - port: {{ .Values.ports.draughtsman.name }}
       protocol: {{ .Values.ports.draughtsman.protocol }}
   egress:
-  - to:
-    - ipBlock:
-        cidr: 10.0.0.0/8
-    - ipBlock:
-        cidr: 172.16.0.0/12
-    - ipBlock:
-        cidr: 192.168.0.0/16
+  - {}  
   policyTypes:
   - Egress
   - Ingress

--- a/helm/draughtsman-chart/templates/network-policy.yaml
+++ b/helm/draughtsman-chart/templates/network-policy.yaml
@@ -2,11 +2,11 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   namespace: {{ .Values.resource.default.namespace }}
-  name: {{ .Values.resource.default.name }}
+  name: {{ tpl .Values.resource.default.name . }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ .Values.resource.default.name }}
+      app: {{ tpl .Values.resource.default.name . }}
   ingress:
   - ports:
     - port: {{ .Values.ports.draughtsman.name }}

--- a/helm/draughtsman-chart/values.yaml
+++ b/helm/draughtsman-chart/values.yaml
@@ -1,0 +1,35 @@
+image:
+  registry: "quay.io"
+  repository: "giantswarm/draughtsman"
+  tag: "[[ .SHA ]]"
+pod:
+  user:
+    id: 0
+  group:
+    id: 1000
+ports:
+  draughtsman:
+    name: draughtsman
+    port: 8000
+    protocol: TCP
+# Resource names are truncated to 47 characters. Kubernetes allows 63 characters
+# limit for resource names. When pods for deployments are created they have
+# additional 16 characters suffix, e.g. "-957c9d6ff-pkzgw" and we want to have
+# room for those suffixes.
+#
+# NOTE: All values under resource key need to be used with `tpl` to render them
+# correctly in the templates. This is because helm doesn't template values.yaml
+# file and it has to be a valid json. Example usage:
+#
+#     {{ tpl .Values.resource.default.name . }}.
+#
+resource:
+  configMap:
+    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-configmap'
+  default:
+    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}'
+    namespace: giantswarm
+  psp:
+    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-psp'
+  pullSecret:
+    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-pull-secret'

--- a/helm/draughtsman-chart/values.yaml
+++ b/helm/draughtsman-chart/values.yaml
@@ -2,11 +2,6 @@ image:
   registry: "quay.io"
   repository: "giantswarm/draughtsman"
   tag: "[[ .SHA ]]"
-pod:
-  user:
-    id: 0
-  group:
-    id: 1000
 ports:
   draughtsman:
     name: draughtsman


### PR DESCRIPTION
Towards giantswarm/giantswarm/issues/4383

I'd appreciate some input on this; this is the first one I've worked on and I'd like to make it as locked-down as possible as well as supporting a future deny-all policy in kube-system/giantswarm namespaces.

Tcpdumping traffic to draughtsman shows the only traffic in the 10./192. ranges, however draughtsman needs to poll github for deployment events.