### PR TITLE
Log response body on unexpected response code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
-version: 2
+version: 2.1
+
 jobs:
   build:
     machine: true

--- a/service/eventer/github/client.go
+++ b/service/eventer/github/client.go
@@ -153,7 +153,8 @@ func (e *GithubEventer) fetchNewDeploymentEvents(project string, etagMap map[str
 
 	if resp.StatusCode != http.StatusOK {
 		e.logger.Log("error", "Error fetching deployment events", "project", project)
-		return nil, microerror.Maskf(unexpectedStatusCode, fmt.Sprintf("received non-200 status code: %v", resp.StatusCode))
+		body, _ := ioutil.ReadAll(resp.Body)
+		return nil, microerror.Maskf(unexpectedStatusCode, fmt.Sprintf("received non-200 status code: %v, body: %q", resp.StatusCode, string(body)))
 	}
 
 	bytes, err := ioutil.ReadAll(resp.Body)
@@ -218,7 +219,8 @@ func (e *GithubEventer) fetchDeploymentStatus(project string, deployment deploym
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, microerror.Maskf(unexpectedStatusCode, fmt.Sprintf("received non-200 status code: %v", resp.StatusCode))
+		body, _ := ioutil.ReadAll(resp.Body)
+		return nil, microerror.Maskf(unexpectedStatusCode, fmt.Sprintf("received non-200 status code: %v, body: %q", resp.StatusCode, string(body)))
 	}
 
 	bytes, err := ioutil.ReadAll(resp.Body)
@@ -277,7 +279,8 @@ func (e *GithubEventer) postDeploymentStatus(project string, id int, state deplo
 	}
 
 	if resp.StatusCode != http.StatusCreated {
-		return microerror.Maskf(unexpectedStatusCode, fmt.Sprintf("received non-200 status code: %v", resp.StatusCode))
+		body, _ := ioutil.ReadAll(resp.Body)
+		return microerror.Maskf(unexpectedStatusCode, fmt.Sprintf("received non-200 status code: %v, body: %q", resp.StatusCode, string(body)))
 	}
 
 	return nil


### PR DESCRIPTION
`ginger` installation is broken, and one of the pieces broken there is `draughtsman`, it's getting redeployed every 1-2 min. Between one of the redeploys I managed to get following logs:

```
{"caller":"github.com/giantswarm/draughtsman/service/eventer/github/github.go:99","debug":"starting polling for github deployment events","interval":"1m0s","time":"2019-11-05T08:05:25.978176+00:00"}
{"caller":"github.com/giantswarm/draughtsman/service/eventer/github/github.go:108","debug":"Fetching deployment events","projectlist":["api","app-operator","aws-operator","aws-app-collection","cert-exporter","cert-operator","chart-operator","cluster-operator","cluster-service","companyd","credentiald","draughtsman","etcd-backup","g8s-cert-manager","g8s-efk","g8s-grafana","g8s-oauth2-proxy","g8s-prometheus","happa","kubernetesd","net-exporter","node-operator","passage","release-operator","tokend","userd","vault-exporter"],"time":"2019-11-05T08:05:25.978218+00:00"}
{"caller":"github.com/giantswarm/draughtsman/service/eventer/github/client.go:183","debug":"found new deployment events","project":"draughtsman","time":"2019-11-05T08:05:37.709085+00:00"}
{"caller":"github.com/giantswarm/draughtsman/service/eventer/github/client.go:239","debug":"posting deployment status","id":179805976,"project":"draughtsman","state":"pending","time":"2019-11-05T08:05:37.709233+00:00"}
{"caller":"github.com/giantswarm/draughtsman/service/deployer/deployer.go:169","error":"could not set pending event","message":"received non-200 status code: 422: unexpected status code","time":"2019-11-05T08:05:37.973319+00:00"}
{"caller":"github.com/giantswarm/draughtsman/service/installer/helm/helm.go:209","debug":"installing chart","name":"draughtsman","sha":"b68099e717b4d30953bc52e724afdb52abec9cd4","time":"2019-11-05T08:05:37.973361+00:00"}
```

It seems draughtsman is posting some invalid information to GitHub which is responding with 422, but we don't know what's the problem with posted payload.

This PR adds GitHub response body to error message being logged so we can discover actual problem and have it fixed.