### PR TITLE
Allow draughtsman to terminate gracefully

### DIFF
--- a/helm/draughtsman-chart/templates/deployment.yaml
+++ b/helm/draughtsman-chart/templates/deployment.yaml
@@ -66,5 +66,6 @@ spec:
           limits:
             cpu: 100m
             memory: 150Mi
+      terminationGracePeriodSeconds: 300
       imagePullSecrets:
       - name: draughtsman-pull-secret


### PR DESCRIPTION
Debugging issue with draughtsman self-installation on `ginger` - from draughtsman logs, `helm install` of draughtsman hangs and doesn't return on time, new deployment does kick in and draughtsman replica being replaced gets terminated like immediately, so it doesn't get to label/commit deployment event as processed.

helm install has default timeout of 5min which doesn't seem to be overridden.

This PR is an attempt to give draughtsman replica more time to terminate gracefully - termination period is increased from 30sec to 5min. It shouldn't negatively affect other installations, where draughtsman self-installations seems to be working fine, and `helm install` returns fast enough.