### PR TITLE
Increase preStop timeout from 5 to 30 sec

### DIFF
--- a/helm/draughtsman-chart/templates/deployment.yaml
+++ b/helm/draughtsman-chart/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             exec:
               command:
               - sleep
-              - "5"
+              - "30"
         readinessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
This PR allows more time for draughtsman deployment event processing to successfully complete. It's part of mitigating situation on ginger installation where this processing for yet unknown reasons seems to be taking longer than usual.