### PR TITLE
Revert "Allow draughtsman to terminate gracefully (#92)"

### DIFF
--- a/helm/draughtsman-chart/templates/deployment.yaml
+++ b/helm/draughtsman-chart/templates/deployment.yaml
@@ -66,6 +66,5 @@ spec:
           limits:
             cpu: 100m
             memory: 150Mi
-      terminationGracePeriodSeconds: 300
       imagePullSecrets:
       - name: draughtsman-pull-secret


### PR DESCRIPTION
This reverts changes made in PR https://github.com/giantswarm/draughtsman/pull/92 since draughtsman doesn't have own logic to gracefully handle sigterm (and implementing it is non trivial) so that configuration change didn't help.

@calvix guided in currently better direction, implemented via https://github.com/giantswarm/draughtsman/pull/93 which was actually effective/working.