### PR TITLE
Delete helm release before installing

### DIFF
--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -266,6 +266,15 @@ func (i *HelmInstaller) Install(event eventerspec.DeploymentEvent) error {
 		valuesFilesArgs = append(valuesFilesArgs, "--values", fileName)
 	}
 
+	// We must first delete the current release with that name, since Deployments using apps/v1 have some immutable
+	// fields like the match selector.
+	{
+		err := i.runHelmCommand("delete", project, "--purge")
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	// The arguments used to execute Helm for app installation can take multiple
 	// values files. At the end the command looks something like this.
 	//


### PR DESCRIPTION
Every time we want to deploy `azure-operator` we need to manually delete the helm release, otherwise, it will fail saying that the match selector field is immutable. That's because we use apiversion `apps/v1`.

Would it make sense to change draughtsman to delete the release before installing a chart?