### PR TITLE
Fix panic when not receiving X-RateLimit-Reset header from github api

### DIFF
--- a/service/eventer/github/client.go
+++ b/service/eventer/github/client.go
@@ -326,7 +326,7 @@ func (e *GithubEventer) updateRateLimiter(response *http.Response) error {
 func parseRateLimitValue(response *http.Response) (float64, error) {
 	value := response.Header.Get(rateLimitLimitHeader)
 	if value == "" {
-		return 0.0, microerror.Maskf(missingHeaderError, "%#q header is missing", rateLimitLimitHeader)
+		return 0.0, microerror.Maskf(executionFailedError, "%#q header is missing", rateLimitLimitHeader)
 	}
 	rateLimitLimitValue, err := strconv.ParseFloat(value, 64)
 	if err != nil {

--- a/service/eventer/github/client.go
+++ b/service/eventer/github/client.go
@@ -324,7 +324,11 @@ func (e *GithubEventer) updateRateLimiter(response *http.Response) error {
 // parseRateLimitValue parses GitHub API rate limit value from response
 // headers.
 func parseRateLimitValue(response *http.Response) (float64, error) {
-	rateLimitLimitValue, err := strconv.ParseFloat(response.Header.Get(rateLimitLimitHeader), 64)
+	value := response.Header.Get(rateLimitLimitHeader)
+	if value == "" {
+		return 0.0, microerror.Maskf(missingHeaderError, "%#q header is missing", rateLimitLimitHeader)
+	}
+	rateLimitLimitValue, err := strconv.ParseFloat(value, 64)
 	if err != nil {
 		return 0.0, microerror.Mask(err)
 	}
@@ -334,7 +338,11 @@ func parseRateLimitValue(response *http.Response) (float64, error) {
 // parseRateLimitRemaining parses remaining GitHub API request tokens before
 // rate limiting prevents further requests.
 func parseRateLimitRemaining(response *http.Response) (float64, error) {
-	rateLimitRemainingValue, err := strconv.ParseFloat(response.Header.Get(rateLimitRemainingHeader), 64)
+	value := response.Header.Get(rateLimitRemainingHeader)
+	if value == "" {
+		return 0.0, microerror.Maskf(missingHeaderError, "%#q header is missing", rateLimitRemainingHeader)
+	}
+	rateLimitRemainingValue, err := strconv.ParseFloat(value, 64)
 	if err != nil {
 		return 0.0, microerror.Mask(err)
 	}
@@ -345,7 +353,11 @@ func parseRateLimitRemaining(response *http.Response) (float64, error) {
 // parseRateLimitResetTime parses time when GitHub API's rate limit bucket gets
 // refilled.
 func parseRateLimitResetTime(response *http.Response) (time.Time, error) {
-	rateLimitResetValue, err := strconv.ParseInt(response.Header.Get(rateLimitResetHeader), 10, 64)
+	value := response.Header.Get(rateLimitResetHeader)
+	if value == "" {
+		return time.Time{}, microerror.Maskf(missingHeaderError, "%#q header is missing", rateLimitResetHeader)
+	}
+	rateLimitResetValue, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		return time.Time{}, microerror.Mask(err)
 	}

--- a/service/eventer/github/client.go
+++ b/service/eventer/github/client.go
@@ -340,7 +340,7 @@ func parseRateLimitValue(response *http.Response) (float64, error) {
 func parseRateLimitRemaining(response *http.Response) (float64, error) {
 	value := response.Header.Get(rateLimitRemainingHeader)
 	if value == "" {
-		return 0.0, microerror.Maskf(missingHeaderError, "%#q header is missing", rateLimitRemainingHeader)
+		return 0.0, microerror.Maskf(executionFailedError, "%#q header is missing", rateLimitRemainingHeader)
 	}
 	rateLimitRemainingValue, err := strconv.ParseFloat(value, 64)
 	if err != nil {

--- a/service/eventer/github/client.go
+++ b/service/eventer/github/client.go
@@ -355,7 +355,7 @@ func parseRateLimitRemaining(response *http.Response) (float64, error) {
 func parseRateLimitResetTime(response *http.Response) (time.Time, error) {
 	value := response.Header.Get(rateLimitResetHeader)
 	if value == "" {
-		return time.Time{}, microerror.Maskf(missingHeaderError, "%#q header is missing", rateLimitResetHeader)
+		return time.Time{}, microerror.Maskf(executionFailedError, "%#q header is missing", rateLimitResetHeader)
 	}
 	rateLimitResetValue, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {

--- a/service/eventer/github/error.go
+++ b/service/eventer/github/error.go
@@ -4,6 +4,10 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/service/eventer/github/error.go
+++ b/service/eventer/github/error.go
@@ -17,15 +17,6 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
-var missingHeaderError = &microerror.Error{
-	Kind: "missingHeaderError",
-}
-
-// IsMissingHeaderError asserts missingHeaderError.
-func IsMissingHeaderError(err error) bool {
-	return microerror.Cause(err) == missingHeaderError
-}
-
 var unexpectedStatusCode = &microerror.Error{
 	Kind: "unexpectedStatusCode",
 }

--- a/service/eventer/github/error.go
+++ b/service/eventer/github/error.go
@@ -1,19 +1,32 @@
 package github
 
 import (
-	"github.com/juju/errgo"
+	"github.com/giantswarm/microerror"
 )
 
-var invalidConfigError = errgo.New("invalid config")
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
 
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
-	return errgo.Cause(err) == invalidConfigError
+	return microerror.Cause(err) == invalidConfigError
 }
 
-var unexpectedStatusCode = errgo.New("unexpected status code")
+var missingHeaderError = &microerror.Error{
+	Kind: "missingHeaderError",
+}
+
+// IsMissingHeaderError asserts missingHeaderError.
+func IsMissingHeaderError(err error) bool {
+	return microerror.Cause(err) == missingHeaderError
+}
+
+var unexpectedStatusCode = &microerror.Error{
+	Kind: "unexpectedStatusCode",
+}
 
 // IsUnexpectedStatusCode asserts unexpectedStatusCode.
 func IsUnexpectedStatusCode(err error) bool {
-	return errgo.Cause(err) == unexpectedStatusCode
+	return microerror.Cause(err) == unexpectedStatusCode
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/9507

This PR fix an issue where draughtsman crashes when the `X-RateLimit-Reset` header is not present in github api responses.
I went ahead and fixed all `parseRateLimit*` functions, which now return an error in case the header is not found.

I suspect this is happening when github respond with 5xx, since 200, 304, and 403 (exceed the rate limit) have those headers according to the doc.