### PR TITLE
Adding app-operator into draughtsman project

### DIFF
--- a/service/eventer/projects.go
+++ b/service/eventer/projects.go
@@ -3,6 +3,7 @@ package eventer
 var (
 	commonProjectList = []string{
 		"api",
+		"app-operator",
 		"cluster-operator",
 		"credentiald",
 		"draughtsman",


### PR DESCRIPTION
Toward giantswarm/giantswarm#10798

Bring back app-operator into draughsman, so we can deploy thiccc branch.