### PR TITLE
Add app-operator thiccc deployment to test control planes

### DIFF
--- a/service/eventer/projects.go
+++ b/service/eventer/projects.go
@@ -25,6 +25,9 @@ var (
 		"argali":  []string{"route53-manager"},
 		"axolotl": []string{"route53-manager"},
 		"gauss":   []string{"release-bot"},
-		"giraffe": []string{"route53-manager"},
+		"giraffe": []string{
+			"app-operator",
+			"route53-manager",
+		},
 	}
 )

--- a/service/eventer/projects.go
+++ b/service/eventer/projects.go
@@ -24,10 +24,16 @@ var (
 	perInstallationProjectLists = map[string][]string{
 		"argali":  []string{"route53-manager"},
 		"axolotl": []string{"route53-manager"},
-		"gauss":   []string{"release-bot"},
+		"gaia":    []string{"app-operator"},
+		"gauss":   []string{"gauss, release-bot"},
+		"geckon":  []string{"app-operator"},
+		"ghost":   []string{"app-operator"},
+		"ginger":  []string{"app-operator"},
 		"giraffe": []string{
 			"app-operator",
 			"route53-manager",
 		},
+		"godsmack": []string{"app-operator"},
+		"gorgoth":  []string{"app-operator"},
 	}
 )


### PR DESCRIPTION
Temporary fix to run the thiccc app-operator in all test control planes.

Will be replaced by https://github.com/giantswarm/draughtsman/pull/111 next week once all control planes are upgraded to Helm 3.