### PR TITLE
Ensure ratelimiter fill interval is positive

### DIFF
--- a/service/eventer/github/client.go
+++ b/service/eventer/github/client.go
@@ -300,7 +300,7 @@ func (e *GithubEventer) updateRateLimiter(response *http.Response) error {
 	}
 
 	timeToRefill := rateLimitResetTime.Sub(time.Now())
-	//  This is needed because rateLimiter accepts positive intervals only.
+	// This is needed because rateLimiter accepts positive intervals only.
 	if timeToRefill <= 0 {
 		timeToRefill = 1 * time.Second
 	}

--- a/service/eventer/github/client.go
+++ b/service/eventer/github/client.go
@@ -300,6 +300,11 @@ func (e *GithubEventer) updateRateLimiter(response *http.Response) error {
 	}
 
 	timeToRefill := rateLimitResetTime.Sub(time.Now())
+	// If for some reason the timeToRefill is in the past, set it to 1s. This
+	// is needed because rateLimiter accepts positive intervals only.
+	if timeToRefill <= 0 {
+		timeToRefill = 1 * time.Second
+	}
 
 	// If we are close to hit the rate limit, wait some extra time.
 	if rateLimitRemaining < rateLimitAlmostHitThreshold {

--- a/service/eventer/github/client.go
+++ b/service/eventer/github/client.go
@@ -300,8 +300,7 @@ func (e *GithubEventer) updateRateLimiter(response *http.Response) error {
 	}
 
 	timeToRefill := rateLimitResetTime.Sub(time.Now())
-	// If for some reason the timeToRefill is in the past, set it to 1s. This
-	// is needed because rateLimiter accepts positive intervals only.
+	//  This is needed because rateLimiter accepts positive intervals only.
 	if timeToRefill <= 0 {
 		timeToRefill = 1 * time.Second
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11108

If `rateLimitResetTime` is in the past for some reason, we need to manually set `timeToRefill` to a small positive value.