### PR TITLE
eventer: remove release-bot

### DIFF
--- a/service/eventer/projects.go
+++ b/service/eventer/projects.go
@@ -21,7 +21,6 @@ var (
 		"gaia": []string{"app-operator"},
 		"gauss": []string{
 			"app-operator",
-			"release-bot",
 		},
 		"geckon": []string{"app-operator"},
 		"ghost":  []string{"app-operator"},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10177

It is not used anymore.