### PR TITLE
Reset metrics on every * mins

### DIFF
--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -243,6 +243,9 @@ func (i *HelmInstaller) checkHelmRelease(projectList []string) {
 		if err != nil {
 			i.logger.Log("error", "could not parse helm history output", err.Error())
 		}
+
+		helmReleaseFailure.Reset()
+
 		if len(v) > 0 {
 			reportHelmRelease(prj, strings.ToLower(v[0]["status"]))
 		} else {

--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -226,6 +226,7 @@ func (i *HelmInstaller) fetchMetrics() error {
 }
 
 func (i *HelmInstaller) checkHelmRelease(projectList []string) {
+	// Reset the last metrics in this vector so only new metrics could be reported.
 	helmReleaseFailure.Reset()
 	for _, prj := range projectList {
 		cmd := exec.Command(i.helmBinaryPath, "history", prj, "--output", "yaml", "--max", "1")

--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -226,6 +226,7 @@ func (i *HelmInstaller) fetchMetrics() error {
 }
 
 func (i *HelmInstaller) checkHelmRelease(projectList []string) {
+	helmReleaseFailure.Reset()
 	for _, prj := range projectList {
 		cmd := exec.Command(i.helmBinaryPath, "history", prj, "--output", "yaml", "--max", "1")
 
@@ -243,8 +244,6 @@ func (i *HelmInstaller) checkHelmRelease(projectList []string) {
 		if err != nil {
 			i.logger.Log("error", "could not parse helm history output", err.Error())
 		}
-
-		helmReleaseFailure.Reset()
 
 		if len(v) > 0 {
 			reportHelmRelease(prj, strings.ToLower(v[0]["status"]))


### PR DESCRIPTION
For every * minute, we need to reset gauge metrics from draughtsman to prevent presenting duplicate metrics as below. 
```
draughtsman_helm_installer_helm_release_failed gauge
draughtsman_helm_installer_helm_release_failed{name="aws-app-collection",status="deployed"} 1
draughtsman_helm_installer_helm_release_failed{name="aws-app-collection",status="failed"} 1
```