### PR TITLE
Remove thiccc version of app-operator

### DIFF
--- a/pkg/project/configuration/configuration.go
+++ b/pkg/project/configuration/configuration.go
@@ -20,24 +20,8 @@ var (
 			"azure-operator",
 		},
 	}
-
-	perInstallationProjectLists = map[string][]string{
-		"gaia": {"app-operator"},
-		"gauss": {
-			"app-operator",
-		},
-		"geckon": {"app-operator"},
-		"ghost":  {"app-operator"},
-		"ginger": {"app-operator"},
-		"giraffe": {
-			"app-operator",
-		},
-		"godsmack": {"app-operator"},
-		"gorgoth":  {"app-operator"},
-	}
 )
 
 func GetProjectList(provider, installation string) []string {
-	list := append(commonProjectList, providerProjectList[provider]...)
-	return append(list, perInstallationProjectLists[installation]...)
+	return append(commonProjectList, providerProjectList[provider]...)
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10973

We found a better way to do this. We now have a helm2 branch in app-operator that is deployed as v1.0.8. We will keep this app CR deployed and will add v2.0.0 with Helm 3 support for TCs later. 

