### PR TITLE
removed azure operator beacuse it doesn't have a thiccc branch any more

### DIFF
--- a/service/eventer/projects.go
+++ b/service/eventer/projects.go
@@ -15,7 +15,6 @@ var (
 	}
 	azureProjectList = []string{
 		"azure-app-collection",
-		"azure-operator",
 	}
 	perInstallationProjectLists = map[string][]string{
 		"gaia": []string{"app-operator"},


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/12309

Removed `azure-operator` from the eventer projects.