### PR TITLE
Remove kvm-operator and cluster-operator for KVM

### DIFF
--- a/pkg/project/configuration/configuration.go
+++ b/pkg/project/configuration/configuration.go
@@ -12,9 +12,7 @@ var (
 			"cluster-operator",
 		},
 		"kvm": {
-			"cluster-operator",
 			"kvm-app-collection",
-			"kvm-operator",
 		},
 		"azure": {
 			"azure-app-collection",

--- a/service/eventer/projects.go
+++ b/service/eventer/projects.go
@@ -11,7 +11,6 @@ var (
 	}
 	kvmProjectList = []string{
 		"kvm-app-collection",
-		"kvm-operator",
 	}
 	azureProjectList = []string{
 		"azure-app-collection",


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13911

We no longer have any KVM clusters running tenant cluster releases 9.0.0 (the last active release to use thiccc kvm-operator and cluster-operator) or older.