### PR TITLE
Upgrade on actual namespace where draughtsman installed

### DIFF
--- a/flag/flag.go
+++ b/flag/flag.go
@@ -3,10 +3,12 @@ package flag
 import (
 	"github.com/giantswarm/microkit/flag"
 
+	"github.com/giantswarm/draughtsman/flag/release"
 	"github.com/giantswarm/draughtsman/flag/service"
 )
 
 type Flag struct {
+	Release release.Release
 	Service service.Service
 }
 

--- a/flag/release/release.go
+++ b/flag/release/release.go
@@ -1,0 +1,5 @@
+package release
+
+type Release struct {
+	Namespace string
+}

--- a/helm/draughtsman-chart/templates/configmap.yaml
+++ b/helm/draughtsman-chart/templates/configmap.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: draughtsman
 data:
   config.yaml: |
+    release:
+      namespace: {{ .Release.Namespace }}
     service:
       deployer:
         provider: {{ .Values.Installation.V1.Provider.Kind }}

--- a/main.go
+++ b/main.go
@@ -183,6 +183,8 @@ func mainError() error {
 
 	daemonCommand.PersistentFlags().String(f.Service.HelmMigration.Image.Repository, "quay.io", "image repository for helm migration image.")
 
+	daemonCommand.PersistentFlags().String(f.Release.Namespace, "draughtsman", "release namespace where draughtsman reside.")
+
 	newCommand.CobraCommand().Execute()
 
 	return nil

--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -188,7 +188,7 @@ func (i *HelmInstaller) chartName(project, sha string) string {
 
 // runHelmCommand runs the given Helm command.
 func (i *HelmInstaller) runHelmCommand(name string, args ...string) error {
-	i.logger.Log("debug", "running helm command", "name", name, "command", args)
+	i.logger.Log("debug", "running helm command", "name", name)
 
 	defer updateHelmMetrics(name, time.Now())
 
@@ -378,9 +378,6 @@ func (i *HelmInstaller) Install(event eventerspec.DeploymentEvent) error {
 		installCommand = append(installCommand, namespaceArgs...)
 		installCommand = append(installCommand, project, chartPath)
 
-		for n, c := range installCommand {
-			i.logger.Log("msg", fmt.Sprintf("install command: %d, %q", n, c))
-		}
 		err := i.runHelmCommand("install", installCommand...)
 		if err != nil {
 			return microerror.Mask(err)

--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -188,7 +188,7 @@ func (i *HelmInstaller) chartName(project, sha string) string {
 
 // runHelmCommand runs the given Helm command.
 func (i *HelmInstaller) runHelmCommand(name string, args ...string) error {
-	i.logger.Log("debug", "running helm command", "name", name)
+	i.logger.Log("debug", "running helm command", "name", name, "command", args)
 
 	defer updateHelmMetrics(name, time.Now())
 

--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -46,6 +46,7 @@ type Config struct {
 	// Settings.
 	Environment    string
 	HelmBinaryPath string
+	Namespace      string
 	Organisation   string
 	Password       string
 	Provider       string
@@ -91,6 +92,9 @@ func New(config Config) (*HelmInstaller, error) {
 	if config.HelmBinaryPath == "" {
 		return nil, microerror.Maskf(invalidConfigError, "helm binary path must not be empty")
 	}
+	if config.Namespace == "" {
+		return nil, microerror.Maskf(invalidConfigError, "release namespace must not be empty")
+	}
 	if config.Organisation == "" {
 		return nil, microerror.Maskf(invalidConfigError, "organisation must not be empty")
 	}
@@ -121,6 +125,7 @@ func New(config Config) (*HelmInstaller, error) {
 		// Settings.
 		environment:    config.Environment,
 		helmBinaryPath: config.HelmBinaryPath,
+		namespace:      config.Namespace,
 		organisation:   config.Organisation,
 		password:       config.Password,
 		provider:       config.Provider,
@@ -150,6 +155,7 @@ type HelmInstaller struct {
 	// Settings.
 	environment    string
 	helmBinaryPath string
+	namespace      string
 	organisation   string
 	password       string
 	provider       string
@@ -232,7 +238,7 @@ func (i *HelmInstaller) checkHelmRelease(projectList []string) {
 
 		args := []string{"history", prj, "--output", "yaml", "--max", "1", "--namespace"}
 		if prj == "draughtsman" {
-			args = append(args, "default")
+			args = append(args, i.namespace)
 		} else {
 			args = append(args, "draughtsman")
 		}
@@ -332,7 +338,7 @@ func (i *HelmInstaller) Install(event eventerspec.DeploymentEvent) error {
 	namespaceArgs := []string{"--namespace"}
 	{
 		if project == "draughtsman" {
-			namespaceArgs = append(namespaceArgs, "default")
+			namespaceArgs = append(namespaceArgs, i.namespace)
 		} else {
 			namespaceArgs = append(namespaceArgs, "draughtsman")
 		}

--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -377,7 +377,7 @@ func (i *HelmInstaller) Install(event eventerspec.DeploymentEvent) error {
 		installCommand = append(installCommand, project, chartPath)
 
 		for n, c := range installCommand {
-			i.logger.Debugf(ctx, "install command: %d, %q", n, c)
+			i.logger.Log("msg", fmt.Sprintf("install command: %d, %q", n, c))
 		}
 		err := i.runHelmCommand("install", installCommand...)
 		if err != nil {

--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -376,6 +376,9 @@ func (i *HelmInstaller) Install(event eventerspec.DeploymentEvent) error {
 		installCommand = append(installCommand, namespaceArgs...)
 		installCommand = append(installCommand, project, chartPath)
 
+		for n, c := range installCommand {
+			i.logger.Debugf(ctx, "install command: %d, %q", n, c)
+		}
 		err := i.runHelmCommand("install", installCommand...)
 		if err != nil {
 			return microerror.Mask(err)

--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -371,7 +371,9 @@ func (i *HelmInstaller) Install(event eventerspec.DeploymentEvent) error {
 	var installCommand []string
 	{
 		installCommand = append(installCommand, "upgrade", "--install")
-		installCommand = append(installCommand, forceArg)
+		if forceArg != "" {
+			installCommand = append(installCommand, forceArg)
+		}
 		installCommand = append(installCommand, valuesFilesArgs...)
 		installCommand = append(installCommand, namespaceArgs...)
 		installCommand = append(installCommand, project, chartPath)

--- a/service/installer/installer.go
+++ b/service/installer/installer.go
@@ -90,6 +90,7 @@ func New(config Config) (spec.Installer, error) {
 
 		helmConfig.Environment = config.Viper.GetString(config.Flag.Service.Deployer.Environment)
 		helmConfig.HelmBinaryPath = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Helm.HelmBinaryPath)
+		helmConfig.Namespace = config.Viper.GetString(config.Flag.Release.Namespace)
 		helmConfig.Organisation = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Helm.Organisation)
 		helmConfig.Password = config.Viper.GetString(config.Flag.Service.Deployer.Installer.Helm.Password)
 		helmConfig.Provider = config.Viper.GetString(config.Flag.Service.Deployer.Provider)


### PR DESCRIPTION
Migrating 23 draughtsmen from the `default` namespace to  `draughtsman` requires too much effort. And I think we should let it upgrade what namespace it has. 

This change detects the namespace of draughtsmen and applies it later when we upgrade it. 