### PR TITLE
Extend the memory limit and restarting draughtsman on OOM incident

### DIFF
--- a/helm/draughtsman-chart/templates/deployment.yaml
+++ b/helm/draughtsman-chart/templates/deployment.yaml
@@ -68,6 +68,6 @@ spec:
             memory: 150Mi
           limits:
             cpu: 100m
-            memory: 150Mi
+            memory: 200Mi
       imagePullSecrets:
       - name: draughtsman-pull-secret

--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -205,6 +205,14 @@ func (i *HelmInstaller) runHelmCommand(name string, args ...string) error {
 		"stdout", stdOutBuf.String(), "stderr", stdErrBuf.String(),
 	)
 
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		// if exit code is 137, than means it had been killed by kernel OOM.
+		// recreating the pod to avoid from reaching the memory limitation.
+		if exiterr.ExitCode() == 137 {
+			panic("restarting the pod due to OOM issues from helm binary")
+		}
+	}
+
 	if err != nil {
 		return microerror.Maskf(helmError, "error output: %s", stdErrBuf.String())
 	}

--- a/service/installer/helm/helm.go
+++ b/service/installer/helm/helm.go
@@ -206,8 +206,8 @@ func (i *HelmInstaller) runHelmCommand(name string, args ...string) error {
 	)
 
 	if exiterr, ok := err.(*exec.ExitError); ok {
-		// if exit code is 137, than means it had been killed by kernel OOM.
-		// recreating the pod to avoid from reaching the memory limitation.
+		// If exit code is 137, then it had been killed by a kernel OOM.
+		// Recreating the pod to prevent it reaching the memory limit.
 		if exiterr.ExitCode() == 137 {
 			panic("restarting the pod due to OOM issues from helm binary")
 		}


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/16558